### PR TITLE
Windows testing support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.swp
 *.swo
 /.vagrant
+.DS_Store

--- a/roles/common/tasks/download.yml
+++ b/roles/common/tasks/download.yml
@@ -1,27 +1,24 @@
 
 - name: Download package sha1
   get_url: url={{beat_url}}.sha1.txt dest={{workdir}} validate_certs=no
-  register: sha1_file
   when: not ansible_os_family == "Windows"
 
 - name: Download package sha1 (windows)
   win_get_url: url={{beat_url}}.sha1.txt dest={{workdir}}/{{beat_pkg}}.sha1.txt validate_certs=no
-  register: sha1_file
   when: ansible_os_family == "Windows"
 
 - name: Download package
   get_url: url={{beat_url}} dest={{workdir}} validate_certs=no
-  when: sha1_file.changed and not ansible_os_family == "Windows"
+  when: not ansible_os_family == "Windows"
 
 - name: Download package (windows)
-  win_get_url: url={{beat_url}} dest={{workdir}}/{{beat_pkg}} validate_certs=no
-  when: sha1_file.changed
+  win_get_url: url={{beat_url}} dest={{workdir}}/{{beat_pkg}} validate_certs=no force=no
   when: ansible_os_family == "Windows"
 
 - name: Check file (linux)
   shell: chdir={{workdir}} sha1sum -c {{beat_pkg}}.sha1.txt
-  when: ansible_os_family in ["RedHat", "Debian"] and sha1_file.changed
+  when: ansible_os_family in ["RedHat", "Debian"]
 
 - name: Check file (darwin)
   shell: chdir={{workdir}} shasum -c {{beat_pkg}}.sha1.txt
-  when: ansible_os_family == "Darwin" and sha1_file.changed
+  when: ansible_os_family == "Darwin"

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -39,4 +39,4 @@
 
 - name: Install winpcap (windows)
   win_chocolatey: name=winpcap state=present
-  when: ansible_os_family == "Windows"
+  when: ansible_os_family == "Windows" and beat_name == "packetbeat"

--- a/roles/common/vars/main.yml
+++ b/roles/common/vars/main.yml
@@ -1,7 +1,3 @@
-beats:
-  - packetbeat
-  - topbeat
-
 deb_arch: "{{ 'amd64' if ansible_architecture == 'x86_64' else 'i386' }}"
 rpm_arch: "{{ 'x86_64' if ansible_architecture == 'x86_64' else 'i686' }}"
 

--- a/roles/test-install/tasks/main.yml
+++ b/roles/test-install/tasks/main.yml
@@ -14,6 +14,7 @@
 
 - name: Make sure installdir doesn't exist (windows)
   win_file: path={{installdir}} state=absent
+  when: ansible_os_family == "Windows"
 
 - name: Unzip (windows)
   script: unzip.ps1 -file {{workdir}}\\{{beat_pkg}} -destination {{workdir}}
@@ -29,3 +30,4 @@
     that:
       - "installdir_stat.stat.exists"
       - "installdir_stat.stat.isdir"
+  when: ansible_os_family == "Windows"

--- a/roles/test-uninstall/tasks/main.yml
+++ b/roles/test-uninstall/tasks/main.yml
@@ -17,5 +17,9 @@
   when: ansible_os_family == "RedHat"
 
 - name: Delete directory (darwin)
-  shell: rm -r {{installdir}}
-  when: ansible_os_family == "Darwin" and installdir != "" # safeguard
+  file: path={{installdir}} state=absent
+  when: ansible_os_family == "Darwin"
+
+- name: Delete directory (windows)
+  win_file: path={{installdir}} state=absent
+  when: ansible_os_family == "Windows"

--- a/roles/test-win-packetbeat-file/files/run_script.ps1
+++ b/roles/test-win-packetbeat-file/files/run_script.ps1
@@ -1,0 +1,8 @@
+Param($script)
+
+#$dir = Split-Path $script
+#$filename = Split-Path -leaf $script
+
+#Push-Location $dir
+invoke-expression -Command $script
+#Pop-Location

--- a/roles/test-win-packetbeat-file/files/sleep.ps1
+++ b/roles/test-win-packetbeat-file/files/sleep.ps1
@@ -1,0 +1,3 @@
+Params($duration)
+
+Start-Sleep -s $duration

--- a/roles/test-win-packetbeat-file/tasks/main.yml
+++ b/roles/test-win-packetbeat-file/tasks/main.yml
@@ -1,2 +1,32 @@
 - name: Replace configuration file (windows)
   win_copy: src=packetbeat.yml dest={{installdir}}
+
+- name: Install Packetbeat service
+  script: run_script.ps1 -script {{installdir}}\\install-service-packetbeat.ps1
+
+- name: Start packetbeat
+  win_service: name=packetbeat state=started
+
+- name: Curl something
+  win_get_url: url=http://google.com dest=c:\\test-temp.file
+
+- name: Sleep a little
+  script: sleep.ps1 -duration 3
+
+- name: Stat output file
+  win_stat: path={{workdir}}\\output\\packetbeat
+  register: output_stat
+
+- debug: var=output_stat
+
+- name: Check output file
+  assert:
+    that:
+      - "output_stat.stat.exists"
+      - "output_stat.stat.size > 800"
+
+- name: Stop packetbeat
+  win_service: name=packetbeat state=stopped
+
+- name: Uninstall service
+  script: run_script.ps1 -script {{installdir}}\\uninstall-service-packetbeat.ps1

--- a/roles/test-win-topbeat-file/files/replace.ps1
+++ b/roles/test-win-topbeat-file/files/replace.ps1
@@ -1,0 +1,4 @@
+Param($file, $regexp, $replace)
+
+$content = Get-Content -path $file | Out-String
+$content -Replace $regexp, $replace | Out-File $file

--- a/roles/test-win-topbeat-file/files/run_script.ps1
+++ b/roles/test-win-topbeat-file/files/run_script.ps1
@@ -1,0 +1,8 @@
+Param($script)
+
+#$dir = Split-Path $script
+#$filename = Split-Path -leaf $script
+
+#Push-Location $dir
+invoke-expression -Command $script
+#Pop-Location

--- a/roles/test-win-topbeat-file/files/sleep.ps1
+++ b/roles/test-win-topbeat-file/files/sleep.ps1
@@ -1,0 +1,3 @@
+Params($duration)
+
+Start-Sleep -s $duration

--- a/roles/test-win-topbeat-file/files/topbeat.yml
+++ b/roles/test-win-topbeat-file/files/topbeat.yml
@@ -1,0 +1,7 @@
+input:
+  period: 1
+
+output:
+  file:
+    enabled: true
+    path: "c:/users/vagrant/output"

--- a/roles/test-win-topbeat-file/tasks/main.yml
+++ b/roles/test-win-topbeat-file/tasks/main.yml
@@ -1,0 +1,29 @@
+- name: Replace configuration file (windows)
+  win_copy: src=topbeat.yml dest={{installdir}}
+
+- name: Install Topbeat service
+  script: run_script.ps1 -script {{installdir}}\\install-service-topbeat.ps1
+
+- name: Start topbeat
+  win_service: name=topbeat state=started
+
+- name: Sleep a little
+  script: sleep.ps1 -duration 3
+
+- name: Stat output file
+  win_stat: path={{workdir}}\\output\\topbeat
+  register: output_stat
+
+- debug: var=output_stat
+
+- name: Check output file
+  assert:
+    that:
+      - "output_stat.stat.exists"
+      - "output_stat.stat.size > 800"
+
+- name: Stop topbeat
+  win_service: name=topbeat state=stopped
+
+- name: Uninstall service
+  script: run_script.ps1 -script {{installdir}}\\uninstall-service-topbeat.ps1

--- a/run-settings-nightly.yml
+++ b/run-settings-nightly.yml
@@ -1,2 +1,2 @@
 url_base: https://s3.amazonaws.com/beats-nightlies
-version: 1.0.0-nightly.150826232450
+version: 1.0.0-nightly.150902195000

--- a/site.yml
+++ b/site.yml
@@ -52,10 +52,25 @@
     - windows
   tags:
     - packetbeat
+    - windows
   vars:
     - beat_name: packetbeat
   roles:
     - common
     - test-install
     - test-win-packetbeat-file
+    - test-uninstall
+
+- name: E2E windows tests Topbeat
+  hosts:
+    - windows
+  tags:
+    - topbeat
+    - windows
+  vars:
+    - beat_name: topbeat
+  roles:
+    - common
+    - test-install
+    - test-win-topbeat-file
     - test-uninstall


### PR DESCRIPTION
This adds most of the utilities needed for testing on Windows. The
existing test download the zip file, extract it, install Packetbeat
and Topbeat as services, start them, check that they produce output
(without yet checking anything in the output), stop them and remove
the services at the end.

There are lots of Powershell files which workaround missing Ansible
support for windows. I.E. common modules like sleep, replace, run
are implemented in ps1 scripts.