### PR TITLE
Make sure output directory is empty before tests.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,33 @@
 
 Vagrant + Ansible setup for testing the OS packages and basic e2e tests for all
 the [Beats](https://www.elastic.co/products/beats)
+
+
+## Execute
+
+First, you need to bring the machines up:
+
+    vagrant up
+
+and make them known by name to SSH:
+
+    vagrant ssh-config >> ~/.ssh/config
+
+Then you can use Ansible to run the tests. Because they involve lots of VMs and
+commands executed over SSH, these tests are slow (currently 15 minutes in
+total). However, while creating tests or checking something quickly, you can
+use different Ansible commands to execute only a subset.
+
+Here are some execution examples:
+
+* All tests, all platforms, a particular release:
+
+        ansible-playbook -i hosts site.yml -e @run-settings-1.0.0-beta3.yml
+
+* Only a particular Beat, Packetbeat in the example:
+
+        ansible-playbook -i hosts site.yml -e @run-settings-nightly.yml --tags packetbeat
+
+* Only a particular OS, Debian 6 amd64 in the example:
+
+        ansible-playbook -i hosts site.yml -e @run-settings-nightly.yml --limit tester-debian6-64

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -51,6 +51,14 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         testvm.vm.network "private_network", ip: "192.168.33.73"
     end
 
+    config.vm.define "tester-centos7-64" do |testvm|
+        testvm.vm.box = "relativkreativ/centos-7-minimal"
+
+        testvm.ssh.port = 2405
+        testvm.vm.network "forwarded_port", guest: 22, host: testvm.ssh.port
+        testvm.vm.network "private_network", ip: "192.168.33.74"
+    end
+
   config.vm.define "tester-win12-64" do |testvm|
     testvm.vm.box = "tudor_g/win2012"
     testvm.vm.communicator = "winrm"

--- a/hosts
+++ b/hosts
@@ -8,6 +8,7 @@ tester-debian6-64
 [centos]
 tester-centos6-32
 tester-centos6-64
+tester-centos7-64
 
 [darwin]
 localhost

--- a/roles/test-linux-binary/tasks/main.yml
+++ b/roles/test-linux-binary/tasks/main.yml
@@ -6,6 +6,9 @@
     workdir: /tmp
     installdir: /tmp/{{beat_name}}-{{version}}-{{rpm_arch}}
 
+- name: Ensure empty output directory
+  file: path={{workdir}}/output state=absent
+
 - name: Download package sha1
   get_url: url={{beat_url}}.sha1.txt dest={{workdir}} validate_certs=no
 

--- a/roles/test-packetbeat-file/tasks/main.yml
+++ b/roles/test-packetbeat-file/tasks/main.yml
@@ -1,3 +1,6 @@
+- name: Ensure empty output directory
+  file: path={{workdir}}/output state=absent
+
 - name: Disable ES output
   replace: >
     dest={{beat_cfg}}

--- a/roles/test-topbeat-file/tasks/main.yml
+++ b/roles/test-topbeat-file/tasks/main.yml
@@ -1,3 +1,6 @@
+- name: Ensure empty output directory
+  file: path={{workdir}}/output state=absent
+
 - name: Disable ES output
   replace: >
     dest={{beat_cfg}}

--- a/roles/test-win-packetbeat-file/tasks/main.yml
+++ b/roles/test-win-packetbeat-file/tasks/main.yml
@@ -1,3 +1,6 @@
+- name: Ensure empty output directory
+  win_file: path={{workdir}}\\output state=absent
+
 - name: Replace configuration file (windows)
   win_copy: src=packetbeat.yml dest={{installdir}}
 

--- a/roles/test-win-topbeat-file/tasks/main.yml
+++ b/roles/test-win-topbeat-file/tasks/main.yml
@@ -1,3 +1,6 @@
+- name: Ensure empty output directory
+  win_file: path={{workdir}}\\output state=absent
+
 - name: Replace configuration file (windows)
   win_copy: src=topbeat.yml dest={{installdir}}
 

--- a/run-settings-1.0.0-beta3.yml
+++ b/run-settings-1.0.0-beta3.yml
@@ -1,0 +1,2 @@
+url_base: https://download.elastic.co/beats
+version: 1.0.0-beta3

--- a/run-settings-nightly.yml
+++ b/run-settings-nightly.yml
@@ -1,2 +1,2 @@
 url_base: https://s3.amazonaws.com/beats-nightlies
-version: 1.0.0-nightly.150903111232
+version: 1.0.0-nightly.150904094105


### PR DESCRIPTION
I had the issue that tests that didn't work were reported as successful
because an old correct file was lying around. This should fix this case.

Also:
 * Added some executing instructions to the README
 * Added centos7 as test target