### PR TITLE
Update the beats-tester tests for the new configuration files

### DIFF
--- a/roles/test-filebeat-file/tasks/main.yml
+++ b/roles/test-filebeat-file/tasks/main.yml
@@ -1,17 +1,8 @@
 - name: Ensure empty output directory
   file: path={{workdir}}/output state=absent
 
-- name: Disable ES output
-  replace: >
-    dest={{beat_cfg}}
-    regexp='elasticsearch:\n    enabled: true'
-    replace='elasticsearch:\n    enabled: false'
-
-- name: Enable file output
-  replace: >
-    dest={{beat_cfg}}
-    regexp='#file:\n  #  enabled: true\n  #  path: "/tmp/filebeat'
-    replace='file:\n    enabled: true\n    path: "{{workdir}}/output'
+- name: Minimal configuration file
+  template: src={{beat_name}}.yml dest={{beat_cfg}}
 
 - name: Start Filebeat (linux)
   service: name={{beat_name}} state=restarted

--- a/roles/test-filebeat-file/templates/filebeat.yml
+++ b/roles/test-filebeat-file/templates/filebeat.yml
@@ -1,0 +1,11 @@
+filebeat:
+  prospectors:
+    -
+      paths:
+        - /var/log/*.log
+
+output:
+  file:
+    enabled: true
+    path: {{workdir}}/output
+    filename: filebeat

--- a/roles/test-linux-binary/tasks/main.yml
+++ b/roles/test-linux-binary/tasks/main.yml
@@ -27,26 +27,8 @@
     regexp='elasticsearch:\n    enabled: true'
     replace='elasticsearch:\n    enabled: false'
 
-- name: Enable file output (packetbeat)
-  replace: >
-    dest={{beat_cfg}}
-    regexp='#file:\n  #  enabled: true\n  #  path: "/tmp/packetbeat'
-    replace='file:\n    enabled: true\n    path: "{{workdir}}/output'
-  when: beat_name == "packetbeat"
-
-- name: Enable file output (topbeat)
-  replace: >
-    dest={{beat_cfg}}
-    regexp='#file:\n  #  enabled: true\n  #  path: "/tmp/topbeat"\n  #  filename: topbeat'
-    replace='file:\n    enabled: true\n    path: "{{workdir}}/output"\n    filename: topbeat'
-  when: beat_name == "topbeat"
-
-- name: Set Period to 1 second
-  replace: >
-    dest="{{beat_cfg}}"
-    regexp='period: 10'
-    replace='period: 1'
-  when: beat_name == "topbeat"
+- name: Minimal configuration file
+  template: src={{beat_name}}.yml dest={{beat_cfg}}
 
 - name: Start in bg
   shell: chdir={{installdir}} ./{{beat_name}} -c {{beat_name}}.yml

--- a/roles/test-linux-binary/templates/filebeat.yml
+++ b/roles/test-linux-binary/templates/filebeat.yml
@@ -1,0 +1,11 @@
+filebeat:
+  prospectors:
+    -
+      paths:
+        - /var/log/*.log
+
+output:
+  file:
+    enabled: true
+    path: {{workdir}}/output
+    filename: filebeat

--- a/roles/test-linux-binary/templates/packetbeat.yml
+++ b/roles/test-linux-binary/templates/packetbeat.yml
@@ -1,0 +1,8 @@
+protocols:
+  http:
+    ports: [80]
+
+output:
+  file:
+    enabled: true
+    path: {{workdir}}/output

--- a/roles/test-linux-binary/templates/topbeat.yml
+++ b/roles/test-linux-binary/templates/topbeat.yml
@@ -1,0 +1,8 @@
+input:
+  period: 1
+
+output:
+  file:
+    enabled: true
+    path: {{workdir}}/output
+    filename: topbeat

--- a/roles/test-packetbeat-file/tasks/main.yml
+++ b/roles/test-packetbeat-file/tasks/main.yml
@@ -1,17 +1,8 @@
 - name: Ensure empty output directory
   file: path={{workdir}}/output state=absent
 
-- name: Disable ES output
-  replace: >
-    dest={{beat_cfg}}
-    regexp='elasticsearch:\n    enabled: true'
-    replace='elasticsearch:\n    enabled: false'
-
-- name: Enable file output
-  replace: >
-    dest={{beat_cfg}}
-    regexp='#file:\n  #  enabled: true\n  #  path: "/tmp/packetbeat'
-    replace='file:\n    enabled: true\n    path: "{{workdir}}/output'
+- name: Minimal configuration file
+  template: src={{beat_name}}.yml dest={{beat_cfg}}
 
 - name: Start Packetbeat (linux)
   service: name=packetbeat state=restarted

--- a/roles/test-packetbeat-file/templates/packetbeat.yml
+++ b/roles/test-packetbeat-file/templates/packetbeat.yml
@@ -1,0 +1,11 @@
+protocols:
+  http:
+    ports: [80]
+
+interfaces:
+  device: {{ "en0" if ansible_os_family == "Darwin" else "any" }}
+
+output:
+  file:
+    enabled: true
+    path: {{workdir}}/output

--- a/roles/test-topbeat-file/tasks/main.yml
+++ b/roles/test-topbeat-file/tasks/main.yml
@@ -7,17 +7,8 @@
     regexp='elasticsearch:\n    enabled: true'
     replace='elasticsearch:\n    enabled: false'
 
-- name: Enable file output
-  replace: >
-    dest={{beat_cfg}}
-    regexp='#file:\n  #  enabled: true\n  #  path: "/tmp/topbeat"\n  #  filename: topbeat'
-    replace='file:\n    enabled: true\n    path: "{{workdir}}/output"\n    filename: topbeat'
-
-- name: Set Period to 1 second
-  replace: >
-    dest="{{beat_cfg}}"
-    regexp='period: 10'
-    replace='period: 1'
+- name: Minimal configuration file
+  template: src={{beat_name}}.yml dest={{beat_cfg}}
 
 - name: Start Topbeat (linux)
   service: name=topbeat state=restarted

--- a/roles/test-topbeat-file/templates/topbeat.yml
+++ b/roles/test-topbeat-file/templates/topbeat.yml
@@ -1,0 +1,8 @@
+input:
+  period: 1
+
+output:
+  file:
+    enabled: true
+    path: {{workdir}}/output
+    filename: topbeat

--- a/roles/test-topbeat-file/topebeat.yml
+++ b/roles/test-topbeat-file/topebeat.yml
@@ -1,0 +1,8 @@
+input:
+  period: 1
+
+output:
+  file:
+    enabled: true
+    path: {{workdir}}/output
+    filename: topbeat

--- a/run-settings-1.0.0-beta4.yml
+++ b/run-settings-1.0.0-beta4.yml
@@ -1,0 +1,2 @@
+url_base: https://download.elastic.co/beats
+version: 1.0.0-beta4


### PR DESCRIPTION
The tests used to do regexp replaces in the default configuration
files, most of which fail now because the config files changed
quite a lot in this release.

I changed the approach here and now we provide a minimal
configuration file for each test.

Tested to work on the linux distros and OS X. Windows still giving me headaches.