### PR TITLE
Add the RC1 testing config

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -8,14 +8,6 @@ VAGRANTFILE_API_VERSION = "2"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
-    config.vm.define "tester-es" do |testvm|
-        testvm.vm.box = "puphpet/debian75-x64"
-
-        testvm.ssh.port = 2400
-        testvm.vm.network "forwarded_port", guest: 22, host: testvm.ssh.port
-        testvm.vm.network "private_network", ip: "192.168.33.60"
-    end
-
     config.vm.define "tester-centos6-32" do |testvm|
         testvm.vm.box = "centos32"
         testvm.vm.box_url = "http://puppet-vagrant-boxes.puppetlabs.com/centos-65-i386-virtualbox-puppet.box"

--- a/roles/test-filebeat-file/templates/filebeat.yml
+++ b/roles/test-filebeat-file/templates/filebeat.yml
@@ -2,7 +2,7 @@ filebeat:
   prospectors:
     -
       paths:
-        - /var/log/*.log
+        - /var/log/test.log
 
 output:
   file:

--- a/roles/test-topbeat-file/tasks/main.yml
+++ b/roles/test-topbeat-file/tasks/main.yml
@@ -28,5 +28,5 @@
 - name: On Darwin, it should contain launchd data
   wait_for: >
     path={{workdir}}/output/topbeat timeout=5
-    search_regex='"proc.name":"launchd"'
+    search_regex='"name":"launchd"'
   when: ansible_os_family == "Darwin"

--- a/run-settings-1.0.0-rc1.yml
+++ b/run-settings-1.0.0-rc1.yml
@@ -1,0 +1,2 @@
+url_base: https://download.elastic.co/beats
+version: 1.0.0-rc1


### PR DESCRIPTION
Also:
 * Fixed an issue with the topbeat test on Darwin
 * Removed the tester-es machine which is currently not used.
 * Specify a single monitored file on OSX to make tests more stable