### PR TITLE
Change to allow 'make nightlies' to work

### DIFF
--- a/roles/test-filebeat-file/templates/filebeat.yml
+++ b/roles/test-filebeat-file/templates/filebeat.yml
@@ -6,6 +6,5 @@ filebeat:
 
 output:
   file:
-    enabled: true
     path: {{workdir}}/output
     filename: filebeat

--- a/roles/test-install/files/mv.ps1
+++ b/roles/test-install/files/mv.ps1
@@ -1,0 +1,3 @@
+Param($path, $dest)
+
+Move-Item -path $path -destination $dest

--- a/roles/test-install/files/unzip.ps1
+++ b/roles/test-install/files/unzip.ps1
@@ -4,5 +4,6 @@ $shell = new-object -com shell.application
 $zip = $shell.NameSpace($file)
 foreach($item in $zip.items())
 {
-  $shell.Namespace($destination).copyhere($item)
+  # 0x14 is a copy flag to overwrite existing.
+  $shell.Namespace($destination).copyhere($item, 0x14)
 }

--- a/roles/test-install/tasks/main.yml
+++ b/roles/test-install/tasks/main.yml
@@ -20,6 +20,10 @@
   script: unzip.ps1 -file {{workdir}}\\{{beat_pkg}} -destination {{workdir}}
   when: ansible_os_family == "Windows"
 
+- name: Rename install dir for nightlies
+  script: mv.ps1 -path "{{ workdir }}\\{{ beat_name }}-*-windows" -dest "{{ installdir }}"
+  when: ansible_os_family == "Windows" and version | match(".*nightly.*")
+
 - name: Stat install directory (windows)
   win_stat: path={{installdir}}
   register: installdir_stat

--- a/roles/test-linux-binary/tasks/main.yml
+++ b/roles/test-linux-binary/tasks/main.yml
@@ -18,14 +18,11 @@
 - name: Check file (linux)
   shell: chdir={{workdir}} sha1sum -c {{beat_pkg}}.sha1.txt
 
-- name: Untar
-  shell: chdir={{workdir}} tar xzvf {{beat_pkg}}
+- name: Create install directory
+  file: path={{installdir}} state=directory
 
-- name: Disable ES output
-  replace: >
-    dest={{beat_cfg}}
-    regexp='elasticsearch:\n    enabled: true'
-    replace='elasticsearch:\n    enabled: false'
+- name: Untar
+  shell: chdir={{installdir}} tar xzvf {{workdir}}/{{beat_pkg}} --strip 1 
 
 - name: Minimal configuration file
   template: src={{beat_name}}.yml dest={{beat_cfg}}

--- a/roles/test-linux-binary/templates/filebeat.yml
+++ b/roles/test-linux-binary/templates/filebeat.yml
@@ -6,6 +6,5 @@ filebeat:
 
 output:
   file:
-    enabled: true
     path: {{workdir}}/output
     filename: filebeat

--- a/roles/test-linux-binary/templates/packetbeat.yml
+++ b/roles/test-linux-binary/templates/packetbeat.yml
@@ -4,5 +4,4 @@ protocols:
 
 output:
   file:
-    enabled: true
     path: {{workdir}}/output

--- a/roles/test-linux-binary/templates/topbeat.yml
+++ b/roles/test-linux-binary/templates/topbeat.yml
@@ -3,6 +3,5 @@ input:
 
 output:
   file:
-    enabled: true
     path: {{workdir}}/output
     filename: topbeat

--- a/roles/test-packetbeat-file/templates/packetbeat.yml
+++ b/roles/test-packetbeat-file/templates/packetbeat.yml
@@ -7,5 +7,4 @@ interfaces:
 
 output:
   file:
-    enabled: true
     path: {{workdir}}/output

--- a/roles/test-topbeat-file/tasks/main.yml
+++ b/roles/test-topbeat-file/tasks/main.yml
@@ -1,12 +1,6 @@
 - name: Ensure empty output directory
   file: path={{workdir}}/output state=absent
 
-- name: Disable ES output
-  replace: >
-    dest={{beat_cfg}}
-    regexp='elasticsearch:\n    enabled: true'
-    replace='elasticsearch:\n    enabled: false'
-
 - name: Minimal configuration file
   template: src={{beat_name}}.yml dest={{beat_cfg}}
 

--- a/roles/test-topbeat-file/templates/topbeat.yml
+++ b/roles/test-topbeat-file/templates/topbeat.yml
@@ -3,6 +3,5 @@ input:
 
 output:
   file:
-    enabled: true
     path: {{workdir}}/output
     filename: topbeat

--- a/roles/test-topbeat-file/topebeat.yml
+++ b/roles/test-topbeat-file/topebeat.yml
@@ -3,6 +3,5 @@ input:
 
 output:
   file:
-    enabled: true
     path: {{workdir}}/output
     filename: topbeat

--- a/roles/test-win-filebeat-file/files/filebeat.yml
+++ b/roles/test-win-filebeat-file/files/filebeat.yml
@@ -93,21 +93,18 @@ shipper:
 ############################# Output ############################################
 
 # Configure what outputs to use when sending the data collected by filebeat.
-# You can enable one or multiple outputs by setting enabled option to true.
 output:
 
   # Elasticsearch as output
   # Options:
   # host, port: where Elasticsearch is listening on
   #elasticsearch:
-  #  enabled: true
   #  hosts: ["localhost:9200"]
 
   # Redis as output
   # Options:
   # host, port: where Redis is listening on
   #redis:
-  #  enabled: true
   #  host: localhost
   #  port: 6379
 
@@ -118,6 +115,5 @@ output:
   # rotate_every_kb: maximum size of the files in path
   # number of files: maximum number of files in path
   file:
-    enabled: true
     path: "c:/users/vagrant/output"
     filename: filebeat

--- a/roles/test-win-packetbeat-file/files/packetbeat.yml
+++ b/roles/test-win-packetbeat-file/files/packetbeat.yml
@@ -7,5 +7,4 @@ protocols:
 
 output:
   file:
-    enabled: true
     path: "c:/users/vagrant/output"

--- a/roles/test-win-topbeat-file/files/topbeat.yml
+++ b/roles/test-win-topbeat-file/files/topbeat.yml
@@ -3,5 +3,4 @@ input:
 
 output:
   file:
-    enabled: true
     path: "c:/users/vagrant/output"

--- a/run-settings-nightly.yml
+++ b/run-settings-nightly.yml
@@ -1,2 +1,2 @@
 url_base: https://s3.amazonaws.com/beats-nightlies
-version: nightly.latest
+version: 1.2.0-nightlylatest


### PR DESCRIPTION
When using `version: 1.2.0-nightlylatest` the tests fail because the tar and zip files associated with that version actually contain a directory named after the true nightly version number (i.e. packetbeat-1.2.0-nightly160104123543-windows/). The playbooks expect that after extracting the archive that a directory named `packetbeat-1.2.0-nightlylatest-windows/` will exist. 

- The PR changes the archive extraction behavior so that the playbook can always find the extracted directory.
- It also removes any references to `enabled: true/false` from config files.

I tested the changes with versions `1.2.0-nightlylatest`, `1.1.0-SNAPSHOT`, and `1.0.1`.


