### PR TITLE
Add Winlogbeat test case

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -51,16 +51,21 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         testvm.vm.network "private_network", ip: "192.168.33.74"
     end
 
-  config.vm.define "tester-win12-64" do |testvm|
-    testvm.vm.box = "http://files.ruflin.com/vagrant/windows-wincap-20151021.box"
-    testvm.vm.communicator = "winrm"
-    testvm.vm.network "forwarded_port", host: 3389, guest: 3389
-    testvm.vm.network "forwarded_port", host: 5985, guest: 5985
+    config.vm.define "tester-win12-64" do |testvm|
+	testvm.vm.box = "https://s3.amazonaws.com/beats-files/vagrant/beats-win2012-r2-virtualbox-2015-12-10_1222.box"
 
-    testvm.vm.provider "virtualbox" do |v|
-        v.gui = false
-        v.cpus = 2
-        v.memory = 2048
+	testvm.ssh.port = 2406
+	testvm.vm.network "forwarded_port", guest: 22, host: testvm.ssh.port
+	testvm.vm.network "private_network", ip: "192.168.33.75"
+
+	testvm.vm.communicator = "winrm"
+	testvm.vm.network "forwarded_port", host: 3389, guest: 3389
+	testvm.vm.network "forwarded_port", host: 5985, guest: 5985
+
+	testvm.vm.provider "virtualbox" do |v|
+	    v.gui = false
+	    v.cpus = 2
+	    v.memory = 2048
+	end
     end
-  end
 end

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -36,7 +36,3 @@
 
 # download packages and sha1 files
 - include: download.yml
-
-- name: Install winpcap (windows)
-  win_chocolatey: name=winpcap state=present
-  when: ansible_os_family == "Windows" and beat_name == "packetbeat"

--- a/roles/test-linux-binary/tasks/main.yml
+++ b/roles/test-linux-binary/tasks/main.yml
@@ -22,7 +22,7 @@
   file: path={{installdir}} state=directory
 
 - name: Untar
-  shell: chdir={{installdir}} tar xzvf {{workdir}}/{{beat_pkg}} --strip 1 
+  shell: chdir={{installdir}} tar xzvf {{workdir}}/{{beat_pkg}} --strip 1
 
 - name: Minimal configuration file
   template: src={{beat_name}}.yml dest={{beat_cfg}}

--- a/roles/test-win-winlogbeat-file/files/replace.ps1
+++ b/roles/test-win-winlogbeat-file/files/replace.ps1
@@ -1,0 +1,6 @@
+# Regex based find and replace on a given file. It uses .NET from PowerShell.
+Param($file, $find, $replace)
+
+$content = [System.IO.File]::ReadAllText($file)
+$content = [System.Text.RegularExpressions.Regex]::Replace($content, $find, $replace)
+[System.IO.File]::WriteAllText($file, $content)

--- a/roles/test-win-winlogbeat-file/files/run_script.ps1
+++ b/roles/test-win-winlogbeat-file/files/run_script.ps1
@@ -1,0 +1,4 @@
+# Workaround for lack of a "shell" module for Windows.
+Param($script)
+
+invoke-expression -Command $script

--- a/roles/test-win-winlogbeat-file/files/sleep.ps1
+++ b/roles/test-win-winlogbeat-file/files/sleep.ps1
@@ -1,0 +1,3 @@
+Param($duration)
+
+Start-Sleep -s $duration

--- a/roles/test-win-winlogbeat-file/tasks/main.yml
+++ b/roles/test-win-winlogbeat-file/tasks/main.yml
@@ -1,0 +1,94 @@
+- name: Ensure no previous ProgramData dir exists
+  win_file: path={{ winlogbeat_data_dir }} state=absent
+
+- name: Install Winlogbeat service
+  script: run_script.ps1 -script {{ installdir }}\\install-service-{{ beat_name }}.ps1
+
+- name: Disable elasticsearch output and enable file output
+  script: replace.ps1 -file {{ installdir }}\\winlogbeat.yml -find "{{ item.find | quote }}" -replace "{{ item.replace | quote }}"
+  with_items:
+    - {find: '(?m)(^\s*)(elasticsearch:)', replace: '$1#$2'}
+    - {find: '(?m)(^\s*)(hosts:.*)', replace: '$1#$2'}
+    - {find: '(?m)(^\s*)#(file:.*)', replace: '$1$2'}
+    - {find: '(?s)(\s+file:.*)#(path:)[^\n]*', replace: '$1$2 {{ winlogbeat_data_dir }}/output'}
+
+- name: Start Winlogbeat
+  win_service: name={{ beat_name }} state=started
+
+- name: Sleep a little
+  script: sleep.ps1 -duration 10
+
+- name: Stop Winlogbeat
+  win_service: name={{ beat_name }} state=stopped
+
+- name: Uninstall service
+  script: run_script.ps1 -script {{ installdir }}\\uninstall-service-{{ beat_name }}.ps1
+
+- name: Stat output file
+  win_stat: path={{ winlogbeat_data_dir }}\output\{{ beat_name }}
+  register: output_stat
+
+- debug: var=output_stat
+
+- name: Check output file exists
+  assert:
+    that:
+      - "output_stat.stat.exists"
+      - "output_stat.stat.size > 0"
+
+- name: Verify output contents
+  script: run_script.ps1 -script "'cat {{ winlogbeat_data_dir }}\output\{{ beat_name }} | select -First 1'"
+  register: json_output
+
+- set_fact: event="{{ json_output.stdout | from_json }}"
+
+- debug: var=event
+
+- assert:
+    that:
+      - "'@timestamp' in event"
+      - "'eventLogName' in event"
+      - "'sourceName' in event"
+      - "'count' in event"
+      - "'computerName' in event"
+      - "'type' in event"
+      - "'recordNumber' in event"
+      - "'eventID' in event"
+      - "'level' in event"
+
+- name: Stat log file
+  win_stat: path={{ winlogbeat_data_dir }}\Logs\winlogbeat
+  register: log_stat
+
+- debug: var=log_stat
+
+- name: Check log file
+  assert:
+    that:
+      - "log_stat.stat.exists"
+      - "log_stat.stat.size > 0"
+
+- name: Stat registry file
+  win_stat: path={{ winlogbeat_data_dir }}\.winlogbeat.yml
+  register: registry_stat
+
+- debug: var=registry_stat
+
+- name: Check registry file
+  assert:
+    that:
+      - "registry_stat.stat.exists"
+      - "registry_stat.stat.size > 0"
+
+- name: Verify registry contents
+  script: run_script.ps1 -script "'cat {{ winlogbeat_data_dir }}\\.winlogbeat.yml'"
+  register: registry_output
+
+- set_fact: registry="{{ registry_output.stdout | from_yaml }}"
+
+- debug: var=registry
+
+- assert:
+    that:
+      - "'update_time' in registry"
+      - "'event_logs' in registry"

--- a/roles/test-win-winlogbeat-file/vars/main.yml
+++ b/roles/test-win-winlogbeat-file/vars/main.yml
@@ -1,0 +1,1 @@
+winlogbeat_data_dir: C:/ProgramData/winlogbeat

--- a/site.yml
+++ b/site.yml
@@ -93,3 +93,17 @@
     - test-install
     - test-win-filebeat-file
     - test-uninstall
+
+- name: Packaging windows tests for Winlogbeat
+  hosts:
+    - windows
+  tags:
+    - winlogbeat
+    - windows
+  vars:
+    - beat_name: winlogbeat
+  roles:
+    - common
+    - test-install
+    - test-win-winlogbeat-file
+    - test-uninstall


### PR DESCRIPTION
This PR adds a test case for Winlogbeat. Similar to the other tests, it will

- download Winlogbeat,
- install it as a service,
- modify the provided config file with sed like commands (this differs from the other Beat tests on Windows because they run with a templated config file rather than the one provided in the zip),
- start the service,
- sleep while it reads some events,
- verify that at least one event was read and that it has the required fields,
- verify that a log file exists,
- and verify that a registry file exists and has `event_logs` in it.

This depends on the elastic/beats#622 PR to change the `.yaml` to `.yml`. It will need a retest after that change merges and the nightlies are updated.

Closes #19 