### PR TITLE
Update Winlogbeat test to not expect count because it was removed

### DIFF
--- a/roles/test-win-winlogbeat-file/tasks/main.yml
+++ b/roles/test-win-winlogbeat-file/tasks/main.yml
@@ -49,7 +49,6 @@
       - "'@timestamp' in event"
       - "'log_name' in event"
       - "'source_name' in event"
-      - "'count' in event"
       - "'computer_name' in event"
       - "'type' in event"
       - "'record_number' in event"


### PR DESCRIPTION
`count` was removed in elastic/beats#1218.