### PR TITLE
Update Windows URLs to include architecture (-32).

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -25,8 +25,8 @@
 
 - name: Compute vars (windows)
   set_fact:
-    beat_url: "{{url_base}}/{{beat_name}}/{{beat_name}}-{{version}}-windows.zip"
-    beat_pkg: "{{beat_name}}-{{version}}-windows.zip"
+    beat_url: "{{url_base}}/{{beat_name}}/{{beat_name}}-{{version}}-windows-32.zip"
+    beat_pkg: "{{beat_name}}-{{version}}-windows-32.zip"
     beat_cfg: c:\\users\\vagrant\\{{beat_name}}-{{version}}-windows\\{{beat_name}}.yml
     workdir: c:\\users\\vagrant
     installdir: c:\\users\\vagrant\\{{beat_name}}-{{version}}-windows


### PR DESCRIPTION
This updates the URLs used by beats-tester to get the Windows binaries.

Once we have the 64-bit version of Packetbeat working. We should update beats-tester to test both 32-bit and 64-bit on Windows.