### PR TITLE
Add testing of 64-bit binaries.

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -25,11 +25,11 @@
 
 - name: Compute vars (windows)
   set_fact:
-    beat_url: "{{url_base}}/{{beat_name}}/{{beat_name}}-{{version}}-windows-32.zip"
-    beat_pkg: "{{beat_name}}-{{version}}-windows-32.zip"
+    beat_url: "{{url_base}}/{{beat_name}}/{{beat_name}}-{{version}}-windows-{{win_arch}}.zip"
+    beat_pkg: "{{beat_name}}-{{version}}-windows-{{win_arch}}.zip"
     beat_cfg: c:\\users\\vagrant\\{{beat_name}}-{{version}}-windows\\{{beat_name}}.yml
     workdir: c:\\users\\vagrant
-    installdir: c:\\users\\vagrant\\{{beat_name}}-{{version}}-windows
+    installdir: c:\\users\\vagrant\\{{beat_name}}-{{version}}-windows-{{win_arch}}
   when: ansible_os_family == "Windows"
 
 - debug: var=beat_cfg

--- a/roles/test-install/tasks/main.yml
+++ b/roles/test-install/tasks/main.yml
@@ -22,7 +22,7 @@
 
 - name: Rename install dir for nightlies
   script: mv.ps1 -path "{{ workdir }}\\{{ beat_name }}-*-windows" -dest "{{ installdir }}"
-  when: ansible_os_family == "Windows" and version | match(".*nightly.*")
+  when: ansible_os_family == "Windows"
 
 - name: Stat install directory (windows)
   win_stat: path={{installdir}}

--- a/site.yml
+++ b/site.yml
@@ -52,7 +52,7 @@
     - {role: test-linux-binary, when: ansible_system == "Linux"}
 
 # windows
-- name: Packaging windows tests for Packetbeat
+- name: Packaging windows 32 tests for Packetbeat
   hosts:
     - windows
   tags:
@@ -60,13 +60,29 @@
     - windows
   vars:
     - beat_name: packetbeat
+    - win_arch: 32
   roles:
     - common
     - test-install
     - test-win-packetbeat-file
     - test-uninstall
 
-- name: Packaging windows tests for Topbeat
+- name: Packaging windows 64 tests for Packetbeat
+  hosts:
+    - windows
+  tags:
+    - packetbeat
+    - windows
+  vars:
+    - beat_name: packetbeat
+    - win_arch: 64
+  roles:
+    - common
+    - test-install
+    - test-win-packetbeat-file
+    - test-uninstall
+
+- name: Packaging windows 32 tests for Topbeat
   hosts:
     - windows
   tags:
@@ -74,13 +90,29 @@
     - windows
   vars:
     - beat_name: topbeat
+    - win_arch: 32
   roles:
     - common
     - test-install
     - test-win-topbeat-file
     - test-uninstall
 
-- name: Packaging windows tests for Filebeat
+- name: Packaging windows 64 tests for Topbeat
+  hosts:
+    - windows
+  tags:
+    - topbeat
+    - windows
+  vars:
+    - beat_name: topbeat
+    - win_arch: 64
+  roles:
+    - common
+    - test-install
+    - test-win-topbeat-file
+    - test-uninstall
+
+- name: Packaging windows 32 tests for Filebeat
   hosts:
     - windows
   tags:
@@ -88,13 +120,29 @@
     - windows
   vars:
     - beat_name: filebeat
+    - win_arch: 32
   roles:
     - common
     - test-install
     - test-win-filebeat-file
     - test-uninstall
 
-- name: Packaging windows tests for Winlogbeat
+- name: Packaging windows 64 tests for Filebeat
+  hosts:
+    - windows
+  tags:
+    - filebeat
+    - windows
+  vars:
+    - beat_name: filebeat
+    - win_arch: 64
+  roles:
+    - common
+    - test-install
+    - test-win-filebeat-file
+    - test-uninstall
+
+- name: Packaging windows 32 tests for Winlogbeat
   hosts:
     - windows
   tags:
@@ -102,6 +150,22 @@
     - windows
   vars:
     - beat_name: winlogbeat
+    - win_arch: 32
+  roles:
+    - common
+    - test-install
+    - test-win-winlogbeat-file
+    - test-uninstall
+
+- name: Packaging windows 64 tests for Winlogbeat
+  hosts:
+    - windows
+  tags:
+    - winlogbeat
+    - windows
+  vars:
+    - beat_name: winlogbeat
+    - win_arch: 64
   roles:
     - common
     - test-install


### PR DESCRIPTION
Implements #32 

It adds a fair bit of duplication in the playbook. If you have suggestions to avoid the duplication please let me know.

This depends on elastic/beats#1276.