### PR TITLE
Fix failing Winlogbeat test case due to uncommented template config

### DIFF
--- a/roles/test-win-packetbeat-file/files/sleep.ps1
+++ b/roles/test-win-packetbeat-file/files/sleep.ps1
@@ -1,3 +1,3 @@
-Params($duration)
+Param($duration)
 
 Start-Sleep -s $duration

--- a/roles/test-win-winlogbeat-file/tasks/main.yml
+++ b/roles/test-win-winlogbeat-file/tasks/main.yml
@@ -4,13 +4,8 @@
 - name: Install Winlogbeat service
   script: run_script.ps1 -script {{ installdir }}\\install-service-{{ beat_name }}.ps1
 
-- name: Disable elasticsearch output and enable file output
-  script: replace.ps1 -file {{ installdir }}\\winlogbeat.yml -find "{{ item.find | quote }}" -replace "{{ item.replace | quote }}"
-  with_items:
-    - {find: '(?m)(^\s*)(elasticsearch:)', replace: '$1#$2'}
-    - {find: '(?m)(^\s*)(hosts:.*)', replace: '$1#$2'}
-    - {find: '(?m)(^\s*)#(file:.*)', replace: '$1$2'}
-    - {find: '(?s)(\s+file:.*)#(path:)[^\n]*', replace: '$1$2 {{ winlogbeat_data_dir }}/output'}
+- name: Replace configuration file with template (windows)
+  win_template: src={{beat_name}}.yml dest={{installdir}}
 
 - name: Start Winlogbeat
   win_service: name={{ beat_name }} state=started
@@ -37,7 +32,7 @@
       - "output_stat.stat.size > 0"
 
 - name: Verify output contents
-  script: run_script.ps1 -script "'cat {{ winlogbeat_data_dir }}\output\{{ beat_name }} | select -First 1'"
+  script: run_script.ps1 -script "'cat -Encoding UTF8 {{ winlogbeat_data_dir }}\output\{{ beat_name }} | select -First 1'"
   register: json_output
 
 - set_fact: event="{{ json_output.stdout | from_json }}"

--- a/roles/test-win-winlogbeat-file/templates/winlogbeat.yml
+++ b/roles/test-win-winlogbeat-file/templates/winlogbeat.yml
@@ -1,0 +1,12 @@
+winlogbeat:
+  registry_file: {{ winlogbeat_data_dir }}/.winlogbeat.yml
+  event_logs:
+    - name: Application
+output:
+  file:
+    path: {{ winlogbeat_data_dir }}/output
+logging:
+  to_files: true
+  files:
+    path: {{ winlogbeat_data_dir }}/Logs
+  level: info


### PR DESCRIPTION
- Use a config template for Winlogbeat instead of find/replace on the supplied config file. The template is stored in beats-tester and does not include the Elasticsearch template options that are currently causing the test failure because they were not being commented out.
- Fix a bug that occurs when validating the JSON output of Winlogbeat that contains non-ASCII
characters like a right apostrophe.