### PR TITLE
Adjust for new filenames

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -1,7 +1,7 @@
 - name: Compute vars (debian)
   set_fact:
-    beat_url: "{{ url_base }}/{{beat_name}}/{{beat_name}}_{{version}}_{{deb_arch}}.deb"
-    beat_pkg: "{{beat_name}}_{{version}}_{{deb_arch}}.deb"
+    beat_url: "{{ url_base }}/{{beat_name}}/{{beat_name}}-{{version}}-{{deb_arch}}.deb"
+    beat_pkg: "{{beat_name}}-{{version}}-{{deb_arch}}.deb"
     beat_cfg: "/etc/{{beat_name}}/{{beat_name}}.yml"
     workdir: /root
   when: ansible_os_family == "Debian"
@@ -16,11 +16,11 @@
 
 - name: Compute vars (darwin)
   set_fact:
-    beat_url: "{{url_base}}/{{beat_name}}/{{beat_name}}-{{version}}-darwin.tgz"
-    beat_pkg: "{{beat_name}}-{{version}}-darwin.tgz"
-    beat_cfg: "/tmp/{{beat_name}}-{{version}}-darwin/{{beat_name}}.yml"
+    beat_url: "{{url_base}}/{{beat_name}}/{{beat_name}}-{{version}}-darwin-x64.tar.gz"
+    beat_pkg: "{{beat_name}}-{{version}}-darwin-x64.tar.gz"
+    beat_cfg: "/tmp/{{beat_name}}-{{version}}-darwin-x64/{{beat_name}}.yml"
     workdir: /tmp
-    installdir: /tmp/{{beat_name}}-{{version}}-darwin
+    installdir: /tmp/{{beat_name}}-{{version}}-darwin-x64
   when: ansible_os_family == "Darwin"
 
 - name: Compute vars (windows)

--- a/roles/common/vars/main.yml
+++ b/roles/common/vars/main.yml
@@ -1,3 +1,4 @@
 deb_arch: "{{ 'amd64' if ansible_architecture == 'x86_64' else 'i386' }}"
 rpm_arch: "{{ 'x86_64' if ansible_architecture == 'x86_64' else 'i686' }}"
+bin_arch: "{{ 'x64' if ansible_architecture == 'x86_64' else 'x86' }}"
 

--- a/roles/test-linux-binary/tasks/main.yml
+++ b/roles/test-linux-binary/tasks/main.yml
@@ -1,10 +1,10 @@
 - name: Compute vars (binary)
   set_fact:
-    beat_url: "{{url_base}}/{{beat_name}}/{{beat_name}}-{{version}}-{{rpm_arch}}.tar.gz"
-    beat_pkg: "{{beat_name}}-{{version}}-{{rpm_arch}}.tar.gz"
-    beat_cfg: "/tmp/{{beat_name}}-{{version}}-{{rpm_arch}}/{{beat_name}}.yml"
+    beat_url: "{{url_base}}/{{beat_name}}/{{beat_name}}-{{version}}-linux-{{bin_arch}}.tar.gz"
+    beat_pkg: "{{beat_name}}-{{version}}-linux-{{bin_arch}}.tar.gz"
+    beat_cfg: "/tmp/{{beat_name}}-{{version}}-linux-{{bin_arch}}/{{beat_name}}.yml"
     workdir: /tmp
-    installdir: /tmp/{{beat_name}}-{{version}}-{{rpm_arch}}
+    installdir: /tmp/{{beat_name}}-{{version}}-linux-{{bin_arch}}
 
 - name: Ensure empty output directory
   file: path={{workdir}}/output state=absent

--- a/roles/test-linux-binary/tasks/main.yml
+++ b/roles/test-linux-binary/tasks/main.yml
@@ -48,9 +48,9 @@
 
 - name: Wait for the output file to be created, should contain system load
   wait_for: >
-    path={{workdir}}/output/topbeat timeout=5
+    path={{workdir}}/output/{{beat_name}} timeout=5
     search_regex='"load"'
-  when: beat_name == "topbeat"
+  when: beat_name == "topbeat" or beat_name == "metricbeat"
 
 - name: Check if version number is correct
   shell: chdir={{installdir}} ./{{beat_name}} -version | grep {{ version[0:5] }}

--- a/roles/test-packetbeat-file/tasks/main.yml
+++ b/roles/test-packetbeat-file/tasks/main.yml
@@ -9,7 +9,7 @@
   when: ansible_os_family in ["Debian", "RedHat"]
 
 - name: Start Packetbeat (darwin)
-  shell: chdir={{workdir}}/{{beat_name}}-{{version}}-darwin ./{{beat_name}} -c {{beat_name}}.yml
+  shell: chdir={{installdir}} ./{{beat_name}} -c {{beat_name}}.yml
   when: ansible_os_family == "Darwin"
   async: 45
   poll: 0  # run in bg
@@ -30,5 +30,5 @@
 
 - name: Wait for the output file to be created, should contain type=http
   wait_for: >
-    path={{workdir}}/output/packetbeat timeout=5
+    path={{workdir}}/output/packetbeat timeout=15
     search_regex='"type":"http"'

--- a/run-settings-1.0.0.yml
+++ b/run-settings-1.0.0.yml
@@ -1,3 +1,0 @@
-# Build based on download binary of 1.0.0
-url_base: https://download.elastic.co/beats
-version: 1.0.0

--- a/run-settings-1.0.1.yml
+++ b/run-settings-1.0.1.yml
@@ -1,3 +1,0 @@
-# Build based on download binary of 1.0.1
-url_base: https://download.elastic.co/beats
-version: 1.0.1

--- a/run-settings-1.1.0-SNAPSHOT.yml
+++ b/run-settings-1.1.0-SNAPSHOT.yml
@@ -1,3 +1,0 @@
-# Build based on downloaded snapshot binary for 1.1.0
-url_base: https://download.elastic.co/beats
-version: 1.1.0-SNAPSHOT

--- a/run-settings-1.1.0-latest.yml
+++ b/run-settings-1.1.0-latest.yml
@@ -1,3 +1,0 @@
-# Build based on nightly snapshot of 1.1 branch
-url_base: https://s3.amazonaws.com/beats-nightlies
-version: 1.1.0-nightlylatest

--- a/run-settings-1.1.0.yml
+++ b/run-settings-1.1.0.yml
@@ -1,3 +1,0 @@
-# Build based on downloaded binary for 1.1.0
-url_base: https://download.elastic.co/beats
-version: 1.1.0

--- a/run-settings-1.1.1-SNAPSHOT.yml
+++ b/run-settings-1.1.1-SNAPSHOT.yml
@@ -1,3 +1,0 @@
-# Build based on downloaded snapshot binary for 1.1.1
-url_base: https://download.elastic.co/beats
-version: 1.1.1-SNAPSHOT

--- a/run-settings-1.1.1.yml
+++ b/run-settings-1.1.1.yml
@@ -1,3 +1,0 @@
-# Build based on downloaded binary for 1.1.1
-url_base: https://download.elastic.co/beats
-version: 1.1.1

--- a/run-settings-1.1.2.yml
+++ b/run-settings-1.1.2.yml
@@ -1,3 +1,0 @@
-# Build based on downloaded binary for 1.1.2
-url_base: https://download.elastic.co/beats
-version: 1.1.2

--- a/run-settings-1.2.0-SNAPSHOT.yml
+++ b/run-settings-1.2.0-SNAPSHOT.yml
@@ -1,3 +1,0 @@
-# Build based on downloaded snapshot binary for 1.2.0-SNAPSHOT
-url_base: https://download.elastic.co/beats
-version: 1.2.0-SNAPSHOT

--- a/run-settings-1.2.0-latest.yml
+++ b/run-settings-1.2.0-latest.yml
@@ -1,3 +1,0 @@
-# Build based on nightly snapshot of master
-url_base: https://s3.amazonaws.com/beats-nightlies
-version: 1.2.0-nightlylatest

--- a/run-settings-1.2.0.yml
+++ b/run-settings-1.2.0.yml
@@ -1,3 +1,0 @@
-# Build based on downloaded binary for 1.2.0
-url_base: https://download.elastic.co/beats
-version: 1.2.0

--- a/run-settings-5.0.0-SNAPSHOT.yml
+++ b/run-settings-5.0.0-SNAPSHOT.yml
@@ -1,3 +1,0 @@
-# Build based on downloaded snapshot binary for 5.0.0-alpha1 release
-url_base: https://beats-nightlies.s3.amazonaws.com
-version: 5.0.0-SNAPSHOT

--- a/run-settings-5.0.0-alpha1.yml
+++ b/run-settings-5.0.0-alpha1.yml
@@ -1,3 +1,0 @@
-# Build based on downloaded snapshot binary for 5.0.0-alpha1 release
-url_base: https://download.elastic.co/beats
-version: 5.0.0-alpha1

--- a/run-settings-5.0.0-alpha1SNAPSHOT.yml
+++ b/run-settings-5.0.0-alpha1SNAPSHOT.yml
@@ -1,3 +1,0 @@
-# Build based on downloaded snapshot binary for 5.0.0-alpha1 internal release
-url_base: https://download.elastic.co/beats
-version: 5.0.0-alpha1SNAPSHOT

--- a/run-settings-5.0.0-alpha2.yml
+++ b/run-settings-5.0.0-alpha2.yml
@@ -1,3 +1,0 @@
-# Build based on downloaded snapshot binary for 5.0.0-alpha2 release
-url_base: https://download.elastic.co/beats
-version: 5.0.0-alpha2

--- a/run-settings-5.0.0-alpha3-SNAPSHOT.yml
+++ b/run-settings-5.0.0-alpha3-SNAPSHOT.yml
@@ -1,0 +1,3 @@
+# Build based on downloaded snapshot binary for 5.0.0-alpha3-SNAPSHOT release
+url_base: https://download.elastic.co/beats
+version: 5.0.0-alpha3-SNAPSHOT

--- a/run-settings-5.0.0-alpha3.yml
+++ b/run-settings-5.0.0-alpha3.yml
@@ -1,0 +1,3 @@
+# Build based on downloaded snapshot binary for 5.0.0-alpha3-SNAPSHOT release
+url_base: https://download.elastic.co/beats
+version: 5.0.0-alpha3-SNAPSHOT

--- a/site.yml
+++ b/site.yml
@@ -69,7 +69,7 @@
     - {role: test-linux-binary, when: ansible_system == "Linux"}
 
 # windows
-- name: Packaging windows 32 tests for Packetbeat
+- name: Packaging windows x86 tests for Packetbeat
   hosts:
     - windows
   tags:
@@ -77,14 +77,14 @@
     - windows
   vars:
     - beat_name: packetbeat
-    - win_arch: 32
+    - win_arch: x86
   roles:
     - common
     - test-install
     - test-win-packetbeat-file
     - test-uninstall
 
-- name: Packaging windows 64 tests for Packetbeat
+- name: Packaging windows x64 tests for Packetbeat
   hosts:
     - windows
   tags:
@@ -92,14 +92,14 @@
     - windows
   vars:
     - beat_name: packetbeat
-    - win_arch: 64
+    - win_arch: x64
   roles:
     - common
     - test-install
     - test-win-packetbeat-file
     - test-uninstall
 
-- name: Packaging windows 32 tests for Topbeat
+- name: Packaging windows x86 tests for Topbeat
   hosts:
     - windows
   tags:
@@ -107,14 +107,14 @@
     - windows
   vars:
     - beat_name: topbeat
-    - win_arch: 32
+    - win_arch: x86
   roles:
     - common
     - test-install
     - test-win-topbeat-file
     - test-uninstall
 
-- name: Packaging windows 64 tests for Topbeat
+- name: Packaging windows x64 tests for Topbeat
   hosts:
     - windows
   tags:
@@ -122,14 +122,14 @@
     - windows
   vars:
     - beat_name: topbeat
-    - win_arch: 64
+    - win_arch: x64
   roles:
     - common
     - test-install
     - test-win-topbeat-file
     - test-uninstall
 
-- name: Packaging windows 32 tests for Metricbeat
+- name: Packaging windows x86 tests for Metricbeat
   hosts:
     - windows
   tags:
@@ -137,14 +137,14 @@
     - windows
   vars:
     - beat_name: metricbeat
-    - win_arch: 32
+    - win_arch: x86
   roles:
     - common
     - test-install
     - test-win-metricbeat-file
     - test-uninstall
 
-- name: Packaging windows 64 tests for Metricbeat
+- name: Packaging windows x64 tests for Metricbeat
   hosts:
     - windows
   tags:
@@ -152,14 +152,14 @@
     - windows
   vars:
     - beat_name: metricbeat
-    - win_arch: 64
+    - win_arch: x64
   roles:
     - common
     - test-install
     - test-win-metricbeat-file
     - test-uninstall
 
-- name: Packaging windows 32 tests for Filebeat
+- name: Packaging windows x86 tests for Filebeat
   hosts:
     - windows
   tags:
@@ -167,14 +167,14 @@
     - windows
   vars:
     - beat_name: filebeat
-    - win_arch: 32
+    - win_arch: x86
   roles:
     - common
     - test-install
     - test-win-filebeat-file
     - test-uninstall
 
-- name: Packaging windows 64 tests for Filebeat
+- name: Packaging windows x64 tests for Filebeat
   hosts:
     - windows
   tags:
@@ -182,14 +182,14 @@
     - windows
   vars:
     - beat_name: filebeat
-    - win_arch: 64
+    - win_arch: x64
   roles:
     - common
     - test-install
     - test-win-filebeat-file
     - test-uninstall
 
-- name: Packaging windows 32 tests for Winlogbeat
+- name: Packaging windows x86 tests for Winlogbeat
   hosts:
     - windows
   tags:
@@ -197,14 +197,14 @@
     - windows
   vars:
     - beat_name: winlogbeat
-    - win_arch: 32
+    - win_arch: x86
   roles:
     - common
     - test-install
     - test-win-winlogbeat-file
     - test-uninstall
 
-- name: Packaging windows 64 tests for Winlogbeat
+- name: Packaging windows x64 tests for Winlogbeat
   hosts:
     - windows
   tags:
@@ -212,7 +212,7 @@
     - windows
   vars:
     - beat_name: winlogbeat
-    - win_arch: 64
+    - win_arch: x64
   roles:
     - common
     - test-install


### PR DESCRIPTION
Change the expected filenames for the packages.

Also:
* Cleanups old settings files, adds 5.0.0-alpha3 settings files
* Actually check the results for metricbeat in the binary tests