### PR TITLE
Use x86_64 instead of x64

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -16,11 +16,11 @@
 
 - name: Compute vars (darwin)
   set_fact:
-    beat_url: "{{url_base}}/{{beat_name}}/{{beat_name}}-{{version}}-darwin-x64.tar.gz"
-    beat_pkg: "{{beat_name}}-{{version}}-darwin-x64.tar.gz"
-    beat_cfg: "/tmp/{{beat_name}}-{{version}}-darwin-x64/{{beat_name}}.yml"
+    beat_url: "{{url_base}}/{{beat_name}}/{{beat_name}}-{{version}}-darwin-x86_64.tar.gz"
+    beat_pkg: "{{beat_name}}-{{version}}-darwin-x86_64.tar.gz"
+    beat_cfg: "/tmp/{{beat_name}}-{{version}}-darwin-x86_64/{{beat_name}}.yml"
     workdir: /tmp
-    installdir: /tmp/{{beat_name}}-{{version}}-darwin-x64
+    installdir: /tmp/{{beat_name}}-{{version}}-darwin-x86_64
   when: ansible_os_family == "Darwin"
 
 - name: Compute vars (windows)

--- a/roles/common/vars/main.yml
+++ b/roles/common/vars/main.yml
@@ -1,4 +1,4 @@
 deb_arch: "{{ 'amd64' if ansible_architecture == 'x86_64' else 'i386' }}"
 rpm_arch: "{{ 'x86_64' if ansible_architecture == 'x86_64' else 'i686' }}"
-bin_arch: "{{ 'x64' if ansible_architecture == 'x86_64' else 'x86' }}"
+bin_arch: "{{ 'x86_64' if ansible_architecture == 'x86_64' else 'x86' }}"
 

--- a/site.yml
+++ b/site.yml
@@ -67,7 +67,7 @@
     - test-win-packetbeat-file
     - test-uninstall
 
-- name: Packaging windows x64 tests for Packetbeat
+- name: Packaging windows x86_64 tests for Packetbeat
   hosts:
     - windows
   tags:
@@ -75,7 +75,7 @@
     - windows
   vars:
     - beat_name: packetbeat
-    - win_arch: x64
+    - win_arch: x86_64
   roles:
     - common
     - test-install
@@ -97,7 +97,7 @@
     - test-win-metricbeat-file
     - test-uninstall
 
-- name: Packaging windows x64 tests for Metricbeat
+- name: Packaging windows x86_64 tests for Metricbeat
   hosts:
     - windows
   tags:
@@ -105,7 +105,7 @@
     - windows
   vars:
     - beat_name: metricbeat
-    - win_arch: x64
+    - win_arch: x86_64
   roles:
     - common
     - test-install
@@ -127,7 +127,7 @@
     - test-win-filebeat-file
     - test-uninstall
 
-- name: Packaging windows x64 tests for Filebeat
+- name: Packaging windows x86_64 tests for Filebeat
   hosts:
     - windows
   tags:
@@ -135,7 +135,7 @@
     - windows
   vars:
     - beat_name: filebeat
-    - win_arch: x64
+    - win_arch: x86_64
   roles:
     - common
     - test-install
@@ -157,7 +157,7 @@
     - test-win-winlogbeat-file
     - test-uninstall
 
-- name: Packaging windows x64 tests for Winlogbeat
+- name: Packaging windows x86_64 tests for Winlogbeat
   hosts:
     - windows
   tags:
@@ -165,7 +165,7 @@
     - windows
   vars:
     - beat_name: winlogbeat
-    - win_arch: x64
+    - win_arch: x86_64
   roles:
     - common
     - test-install


### PR DESCRIPTION
This is needed because of the changes in elastic/beats#1865.