### PR TITLE
Fixed tests for metricbeat changes

### DIFF
--- a/roles/test-linux-binary/templates/metricbeat.yml
+++ b/roles/test-linux-binary/templates/metricbeat.yml
@@ -1,6 +1,6 @@
 metricbeat.modules:
   - module: system
-    metricsets: ["cpu"]
+    metricsets: ["cpu", "load"]
     period: 1s
 
 output:

--- a/roles/test-metricbeat-file/tasks/main.yml
+++ b/roles/test-metricbeat-file/tasks/main.yml
@@ -17,7 +17,7 @@
 - name: Wait for the output file to be created, should contain cpu stats
   wait_for: >
     path={{workdir}}/output/metricbeat timeout=5
-    search_regex='"load"'
+    search_regex='"module":"system","name":"cpu"'
 
 - name: On Darwin, it should contain launchd data
   wait_for: >

--- a/roles/test-metricbeat-file/templates/metricbeat.yml
+++ b/roles/test-metricbeat-file/templates/metricbeat.yml
@@ -1,6 +1,6 @@
 metricbeat.modules:
   - module: system
-    metricsets: ["cpu", "process"]
+    metricsets: ["cpu", "process", "load"]
     period: 1s
 
 output:


### PR DESCRIPTION
Load has its own metricset now, so it needs to be enabled.