### PR TITLE
Test default configurations

### DIFF
--- a/roles/test-filebeat-file/tasks/main.yml
+++ b/roles/test-filebeat-file/tasks/main.yml
@@ -3,13 +3,14 @@
 
 - name: Minimal configuration file
   template: src={{beat_name}}.yml dest={{beat_cfg}}
+  when: ansible_os_family in ["Debian", "RedHat"]
 
 - name: Start Filebeat (linux)
   service: name={{beat_name}} state=restarted
   when: ansible_os_family in ["Debian", "RedHat"]
 
 - name: Start Filebeat (darwin)
-  shell: chdir={{installdir}} ./{{beat_name}} -c {{beat_name}}.yml
+  shell: chdir={{installdir}} ./{{beat_name}} -E output.elasticsearch.enabled=false -E output.file.path={{workdir}}/output
   when: ansible_os_family == "Darwin"
   async: 45
   poll: 0  # run in bg

--- a/roles/test-linux-binary/tasks/main.yml
+++ b/roles/test-linux-binary/tasks/main.yml
@@ -24,11 +24,8 @@
 - name: Untar
   shell: chdir={{installdir}} tar xzvf {{workdir}}/{{beat_pkg}} --strip 1
 
-- name: Minimal configuration file
-  template: src={{beat_name}}.yml dest={{beat_cfg}}
-
 - name: Start in bg
-  shell: chdir={{installdir}} ./{{beat_name}} -c {{beat_name}}.yml
+  shell: chdir={{installdir}} ./{{beat_name}} -E output.elasticsearch.enabled=false -E output.file.path={{workdir}}/output -E metricbeat.modules.0.period=1s
   async: 45
   poll: 0  # run in bg
 

--- a/roles/test-metricbeat-file/tasks/main.yml
+++ b/roles/test-metricbeat-file/tasks/main.yml
@@ -3,13 +3,15 @@
 
 - name: Minimal configuration file
   template: src={{beat_name}}.yml dest={{beat_cfg}}
+  when: ansible_os_family != "Darwin"
 
 - name: Start Metricbeat (linux)
   service: name=metricbeat state=restarted
   when: ansible_os_family in ["Debian", "RedHat"]
 
 - name: Start Metricbeat (darwin)
-  shell: chdir={{installdir}} ./{{beat_name}} -c {{beat_name}}.yml
+  shell: chdir={{installdir}} ./{{beat_name}} -E output.elasticsearch.enabled=false -E output.file.path={{workdir}}/output -E metricbeat.modules.0.period=1s
+
   when: ansible_os_family == "Darwin"
   async: 45
   poll: 0  # run in bg

--- a/roles/test-packetbeat-file/tasks/main.yml
+++ b/roles/test-packetbeat-file/tasks/main.yml
@@ -3,13 +3,15 @@
 
 - name: Minimal configuration file
   template: src={{beat_name}}.yml dest={{beat_cfg}}
+  when: ansible_os_family != "Darwin"
 
 - name: Start Packetbeat (linux)
   service: name=packetbeat state=restarted
   when: ansible_os_family in ["Debian", "RedHat"]
 
 - name: Start Packetbeat (darwin)
-  shell: chdir={{installdir}} ./{{beat_name}} -c {{beat_name}}.yml
+  shell: chdir={{installdir}} ./{{beat_name}} -E output.elasticsearch.enabled=false -E output.file.path={{workdir}}/output
+
   when: ansible_os_family == "Darwin"
   async: 45
   poll: 0  # run in bg


### PR DESCRIPTION
Now that we can easily overwrite config settings with -E, we can use the
default configs in the packaging tests. This has the advantage that we test the
default configuration files.

This PR does this for Linux and Darwin. For Windows we need a slightly
different approach, because the tests start the beats as services, so we don't
control the flags.