### PR TITLE
Use virtualenv to get Ansible version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 # Directories
 /.vagrant
 /.idea
+/ve
 
 # Files
 .DS_Store

--- a/Makefile
+++ b/Makefile
@@ -1,20 +1,18 @@
+ve: ve/bin/activate
+ve/bin/activate: requirements.txt
+	@test -d ve || virtualenv ve
+	@ve/bin/pip install -Ur requirements.txt
+	@touch ve/bin/activate
 
 setup:
 	vagrant up
 	vagrant ssh-config >> ~/.ssh/config
 
-# Run build based on RUN_SETTINGS name
-run: setup
-	# Exluding localhost, as localhost is assumed to be Mac OS X with ssh enabled
-	ansible-playbook -i hosts -e @run-settings-${RUN_SETTINGS}.yml --limit 'all:!localhost' site.yml
+run: ve
+	@if test -z "$$RUN_SETTINGS"; then echo "RUN_SETTINGS is not set. For example, try using RUN_SETTINGS=staging."; exit 1; fi
+	ve/bin/ansible-playbook -vvvv -i hosts -e @run-settings-${RUN_SETTINGS}.yml --limit 'all:!localhost' site.yml
 	
-1.1.0:
-	RUN_SETTINGS=1.1.0-latest make run
-	
-1.2.0:
-	RUN_SETTINGS=1.2.0-latest make run
-
-# This destroys all vagrant machines and removes the vagrant related data
+# This destroys all vagrant machines and removes the vagrant related data.
 clean:
 	-vagrant destroy -f
 	-rm -r .vagrant

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+ansible==1.9.6
+pywinrm>=0.2.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 ansible==1.9.6
 pywinrm>=0.2.2
+markupsafe


### PR DESCRIPTION
This pins the Ansible version to 1.9.6 and uses a virtualenv to ensure the tests are executed in a consistent environment.