### PR TITLE
Fix Metricbeat flaky tests (attempt)

### DIFF
--- a/roles/test-linux-binary/tasks/main.yml
+++ b/roles/test-linux-binary/tasks/main.yml
@@ -25,7 +25,7 @@
   shell: chdir={{installdir}} tar xzvf {{workdir}}/{{beat_pkg}} --strip 1
 
 - name: Start in bg
-  shell: chdir={{installdir}} ./{{beat_name}} -E output.elasticsearch.enabled=false -E output.file.path={{workdir}}/output -E metricbeat.modules.0.period=1s
+  shell: chdir={{installdir}} ./{{beat_name}} -E output.elasticsearch.enabled=false -E output.file.path={{workdir}}/output -E metricbeat.modules.0.period=1s -E metricbeat.max_start_delay=0
   async: 45
   poll: 0  # run in bg
 

--- a/roles/test-metricbeat-file/templates/metricbeat.yml
+++ b/roles/test-metricbeat-file/templates/metricbeat.yml
@@ -2,6 +2,7 @@ metricbeat.modules:
   - module: system
     metricsets: ["cpu", "process", "load"]
     period: 1s
+metricbeat.max_start_delay: 0
 
 output:
   file:

--- a/roles/test-win-metricbeat-file/files/metricbeat.yml
+++ b/roles/test-win-metricbeat-file/files/metricbeat.yml
@@ -2,6 +2,7 @@ metricbeat.modules:
   - module: system
     metricsets: ["cpu"]
     period: 1s
+metricbeat.max_start_delay: 0
 
 output:
   file:

--- a/roles/test-win-metricbeat-file/tasks/main.yml
+++ b/roles/test-win-metricbeat-file/tasks/main.yml
@@ -11,7 +11,7 @@
   win_service: name=metricbeat state=started
 
 - name: Sleep a little
-  script: sleep.ps1 -duration 3
+  script: sleep.ps1 -duration 5
 
 - name: Stat output file
   win_stat: path={{workdir}}\\output\\metricbeat

--- a/run-nightlies.yml
+++ b/run-nightlies.yml
@@ -1,0 +1,2 @@
+url_base: https://beats-nightlies.s3.amazonaws.com
+version: 6.0.0-alpha3-SNAPSHOT

--- a/run-settings-staging.yml
+++ b/run-settings-staging.yml
@@ -1,2 +1,2 @@
-url_base: https://staging.elastic.co/5.2.0-9837cecc/downloads/beats
-version: 5.2.0
+url_base: https://staging.elastic.co/5.4.3-001b8eb4/downloads/beats
+version: 5.4.3


### PR DESCRIPTION
* Set `metricbeat.max_startup_delay: 0` to remove the random sleep in tests
* Increase the Windows timeout for Metricbeat
* Added a nightlies setting file, for easier testing