### PR TITLE
Update command to account for module.d setup

### DIFF
--- a/roles/test-linux-binary/tasks/main.yml
+++ b/roles/test-linux-binary/tasks/main.yml
@@ -24,8 +24,15 @@
 - name: Untar
   shell: chdir={{installdir}} tar xzvf {{workdir}}/{{beat_pkg}} --strip 1
 
+- name: Set metricbeat module period to 1s
+  lineinfile:
+    dest: "{{installdir}}/modules.d/system.yml"
+    regexp: '^  period: 10s'
+    line: '  period: 1s'
+  when: beat_name == "metricbeat"
+
 - name: Start in bg
-  shell: chdir={{installdir}} ./{{beat_name}} -E output.elasticsearch.enabled=false -E output.file.path={{workdir}}/output -E metricbeat.modules.0.period=1s -E metricbeat.max_start_delay=0
+  shell: chdir={{installdir}} ./{{beat_name}} -E output.elasticsearch.enabled=false -E output.file.path={{workdir}}/output -E metricbeat.max_start_delay=0
   async: 45
   poll: 0  # run in bg
 


### PR DESCRIPTION
Remove `-E metricbeat.modules.0.period=1s` from the command used to run
Metricbeat because the module with index 0 does not exist anymore. Module
0 was previously the system module, and that is now configured by the
modules.d/system.yml file.

This PR uses Ansible `lineinfile` to modify the modules.d/system.yml file
to contain `period: 1s` instead of `period: 10s`.