### PR TITLE
Update heartbeat service name to heartbeat-elastic

### DIFF
--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -1,0 +1,1 @@
+service_name: "{{ beat_name }}"

--- a/roles/common/vars/main.yml
+++ b/roles/common/vars/main.yml
@@ -1,4 +1,3 @@
 deb_arch: "{{ 'amd64' if ansible_architecture == 'x86_64' else 'i386' }}"
 rpm_arch: "{{ 'x86_64' if ansible_architecture == 'x86_64' else 'i686' }}"
 bin_arch: "{{ 'x86_64' if ansible_architecture == 'x86_64' else 'x86' }}"
-

--- a/roles/test-heartbeat-file/tasks/main.yml
+++ b/roles/test-heartbeat-file/tasks/main.yml
@@ -6,7 +6,7 @@
   when: ansible_os_family in ["Debian", "RedHat"]
 
 - name: Start Heartbeat (linux)
-  service: name={{beat_name}} state=restarted
+  service: name={{service_name}} state=restarted
   when: ansible_os_family in ["Debian", "RedHat"]
 
 - name: Start Heartbeat (darwin)

--- a/roles/test-install/tasks/main.yml
+++ b/roles/test-install/tasks/main.yml
@@ -1,11 +1,11 @@
 # Installs the packages
 
 - name: Remove rpm if it exists
-  yum: name={{beat_name}} state=absent
+  yum: name={{service_name}} state=absent
   when: ansible_os_family == "RedHat"
 
 - name: Remove deb if it exists
-  apt: name={{beat_name}} state=absent
+  apt: name={{service_name}} state=absent
   when: ansible_os_family == "Debian"
 
 - name: Install Debs

--- a/roles/test-uninstall/tasks/main.yml
+++ b/roles/test-uninstall/tasks/main.yml
@@ -1,7 +1,7 @@
 # Stops and uninstalls the packages
 
 - name: Stop (linux)
-  service: name={{beat_name}} state=stopped
+  service: name={{service_name}} state=stopped
   when: ansible_os_family in ["Debian", "RedHat"]
 
 - name: Stop (darwin)
@@ -9,11 +9,11 @@
   when: ansible_os_family in ["Darwin"]
 
 - name: Unistall deb
-  apt: name={{beat_name}} state=absent purge=true
+  apt: name={{service_name}} state=absent purge=true
   when: ansible_os_family == "Debian"
 
 - name: Unistall rpm
-  yum: name={{beat_name}} state=absent
+  yum: name={{service_name}} state=absent
   when: ansible_os_family == "RedHat"
 
 - name: Delete directory (darwin)

--- a/site.yml
+++ b/site.yml
@@ -61,6 +61,7 @@
     - heartbeat
   vars:
     - beat_name: heartbeat
+    - service_name: heartbeat-elastic
   roles:
     - common
     - test-install


### PR DESCRIPTION
The name of the package has changed and so has the name of the service.

The contents of the RPM are as follows. Notice that it's `/etc/init.d/heartbeat-elastic` and `/lib/systemd/system/heartbeat-elastic.service`.

```
/etc/heartbeat/fields.yml
/etc/heartbeat/heartbeat.reference.yml
/etc/heartbeat/heartbeat.yml
/etc/init.d/heartbeat-elastic
/lib/systemd/system/heartbeat-elastic.service
/usr/bin/heartbeat.sh
/usr/share/heartbeat/.build_hash.txt
/usr/share/heartbeat/NOTICE
/usr/share/heartbeat/README.md
/usr/share/heartbeat/bin/heartbeat
/usr/share/heartbeat/bin/heartbeat-god
/usr/share/heartbeat/scripts/migrate_beat_config_1_x_to_5_0.py
```