### PR TITLE
Use a local ssh_config file for Ansible -> VM connectivity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 
 # Files
 .DS_Store
+ssh_config

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,16 @@
 
 setup:
 	vagrant up
-	vagrant ssh-config >> ~/.ssh/config
+	vagrant ssh-config > ssh_config
 
 # Run build based on RUN_SETTINGS name
 run: setup
 	# Exluding localhost, as localhost is assumed to be Mac OS X with ssh enabled
-	ansible-playbook -i hosts -e @run-settings-${RUN_SETTINGS}.yml --limit 'all:!localhost' site.yml
-	
+	ansible-playbook -i hosts --ssh-extra-args '-F ssh_config' -e @run-settings-${RUN_SETTINGS}.yml --limit 'all:!localhost' site.yml
+
 1.1.0:
 	RUN_SETTINGS=1.1.0-latest make run
-	
+
 1.2.0:
 	RUN_SETTINGS=1.2.0-latest make run
 


### PR DESCRIPTION
This eliminates updating the user's real `~/.ssh/config` file, and will also keep all changes local to the Jenkins workspace when testing. I've also ensured that Git will ignore any of these temporary `ssh_config` files, which should not pollute the repository.