### PR TITLE
Fix macos tests for beta1/beta2

### DIFF
--- a/roles/test-filebeat-file/tasks/main.yml
+++ b/roles/test-filebeat-file/tasks/main.yml
@@ -10,7 +10,7 @@
   when: ansible_os_family in ["Debian", "RedHat"]
 
 - name: Start Filebeat (darwin)
-  shell: chdir={{installdir}} ./{{beat_name}} -E output.elasticsearch.enabled=false -E output.file.path={{workdir}}/output
+  shell: chdir={{installdir}} ./{{beat_name}} -E output.elasticsearch.enabled=false -E output.file.path={{workdir}}/output -E "filebeat.prospectors.0.enabled=true" -E "filebeat.prospectors.0.paths=[/var/log/test.log]"
   when: ansible_os_family == "Darwin"
   async: 45
   poll: 0  # run in bg

--- a/roles/test-metricbeat-file/tasks/main.yml
+++ b/roles/test-metricbeat-file/tasks/main.yml
@@ -10,7 +10,7 @@
   when: ansible_os_family in ["Debian", "RedHat"]
 
 - name: Start Metricbeat (darwin)
-  shell: chdir={{installdir}} ./{{beat_name}} -E output.elasticsearch.enabled=false -E output.file.path={{workdir}}/output -E metricbeat.modules.0.period=1s
+  shell: chdir={{installdir}} ./{{beat_name}} -E output.elasticsearch.enabled=false -E output.file.path={{workdir}}/output -E metricbeat.max_start_delay=0s
 
   when: ansible_os_family == "Darwin"
   async: 45
@@ -18,11 +18,5 @@
 
 - name: Wait for the output file to be created, should contain cpu stats
   wait_for: >
-    path={{workdir}}/output/metricbeat timeout=5
+    path={{workdir}}/output/metricbeat timeout=15
     search_regex='"module":"system","name":"cpu"'
-
-- name: On Darwin, it should contain launchd data
-  wait_for: >
-    path={{workdir}}/output/metricbeat timeout=5
-    search_regex='"name":"launchd"'
-  when: ansible_os_family == "Darwin"

--- a/run-settings-staging.yml
+++ b/run-settings-staging.yml
@@ -1,2 +1,2 @@
-url_base: https://staging.elastic.co/5.4.3-001b8eb4/downloads/beats
-version: 5.4.3
+url_base: https://staging.elastic.co/6.0.0-beta1-7e470714/downloads/beats
+version: 6.0.0-beta1

--- a/run-settings-staging.yml
+++ b/run-settings-staging.yml
@@ -1,2 +1,2 @@
-url_base: https://staging.elastic.co/6.0.0-beta1-7e470714/downloads/beats
-version: 6.0.0-beta1
+url_base: https://staging.elastic.co/6.0.0-beta2-d2816397/downloads/beats
+version: 6.0.0-beta2


### PR DESCRIPTION
I already did this fixes for beta1, but forgot to open the PR. They are needed for the macos part of the tests to pass.