### PR TITLE
Update to use sha512

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 # Files
 .DS_Store
 ssh_config
+site.retry

--- a/roles/common/tasks/download.yml
+++ b/roles/common/tasks/download.yml
@@ -1,10 +1,10 @@
 
-- name: Download package sha1
-  get_url: url={{beat_url}}.sha1 dest={{workdir}} validate_certs=no
+- name: Download package sha512
+  get_url: url={{beat_url}}.sha512 dest={{workdir}} validate_certs=no
   when: not ansible_os_family == "Windows"
 
-- name: Download package sha1 (windows)
-  win_get_url: url={{beat_url}}.sha1 dest={{workdir}}/{{beat_pkg}}.sha1 validate_certs=no
+- name: Download package sha512 (windows)
+  win_get_url: url={{beat_url}}.sha512 dest={{workdir}}/{{beat_pkg}}.sha512 validate_certs=no
   when: ansible_os_family == "Windows"
 
 - name: Download package
@@ -16,9 +16,9 @@
   when: ansible_os_family == "Windows"
 
 - name: Check file (linux)
-  shell: chdir={{workdir}} echo "`cat {{beat_pkg}}.sha1`  {{beat_pkg}}" | sha1sum -c
+  shell: chdir={{workdir}} echo "`cat {{beat_pkg}}.sha512`  {{beat_pkg}}" | sha512sum -c
   when: ansible_os_family in ["RedHat", "Debian", "Suse"]
 
 - name: Check file (darwin)
-  shell: chdir={{workdir}} echo "`cat {{beat_pkg}}.sha1`  {{beat_pkg}}" | shasum -c
+  shell: chdir={{workdir}} echo "`cat {{beat_pkg}}.sha512`  {{beat_pkg}}" | shasum -a 512 -c
   when: ansible_os_family == "Darwin"

--- a/roles/test-linux-binary/tasks/main.yml
+++ b/roles/test-linux-binary/tasks/main.yml
@@ -9,14 +9,14 @@
 - name: Ensure empty output directory
   file: path={{workdir}}/output state=absent
 
-- name: Download package sha1
-  get_url: url={{beat_url}}.sha1 dest={{workdir}} validate_certs=no
+- name: Download package sha512
+  get_url: url={{beat_url}}.sha512 dest={{workdir}} validate_certs=no
 
 - name: Download package
   get_url: url={{beat_url}} dest={{workdir}} validate_certs=no
 
 - name: Check file (linux)
-  shell: chdir={{workdir}} echo "`cat {{beat_pkg}}.sha1`  {{beat_pkg}}" | sha1sum -c
+  shell: chdir={{workdir}} echo "`cat {{beat_pkg}}.sha512`  {{beat_pkg}}" | sha512sum -c
 
 - name: Create install directory
   file: path={{installdir}} state=directory

--- a/run-settings-staging.yml
+++ b/run-settings-staging.yml
@@ -1,2 +1,2 @@
-url_base: https://staging.elastic.co/6.0.0-beta2-d2816397/downloads/beats
-version: 6.0.0-beta2
+url_base: https://staging.elastic.co/6.0.0-rc1-c8f2d2ee/downloads/beats
+version: 6.0.0-rc1


### PR DESCRIPTION
Starting with RC1, we publish sha512 files instead of sha1 files. This
updates beats-tester for that change.