### PR TITLE
Add support for testing Amazon Linux

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -87,6 +87,14 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         testvm.vm.network "forwarded_port", guest: 22, host: testvm.ssh.port, host_ip: "127.0.0.1"
         testvm.vm.network "private_network", ip: "192.168.33.77"
     end
+
+    config.vm.define "tester-awslinux" do |testvm|
+        testvm.vm.box = "mvbcoding/awslinux"
+
+        testvm.ssh.port = 2409
+        testvm.vm.network "forwarded_port", guest: 22, host: testvm.ssh.port, host_ip: "127.0.0.1"
+        testvm.vm.network "private_network", ip: "192.168.33.78"
+    end
 end
 
 def ubuntu_provision_python()

--- a/hosts
+++ b/hosts
@@ -11,6 +11,7 @@ tester-centos6-32
 tester-centos6-64
 tester-centos7-64
 tester-opensuse42-64
+tester-awslinux
 
 [darwin]
 localhost


### PR DESCRIPTION
Amazon Linux shows up as RedHat in ansible so no changes were required
to the tests, and they all pass.