### PR TITLE
Update format of sha512 files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 .DS_Store
 ssh_config
 site.retry
+*.log

--- a/roles/common/tasks/download.yml
+++ b/roles/common/tasks/download.yml
@@ -16,9 +16,9 @@
   when: ansible_os_family == "Windows"
 
 - name: Check file (linux)
-  shell: chdir={{workdir}} echo "`cat {{beat_pkg}}.sha512`  {{beat_pkg}}" | sha512sum -c
+  shell: chdir={{workdir}} sha512sum -c {{beat_pkg}}.sha512
   when: ansible_os_family in ["RedHat", "Debian", "Suse"]
 
 - name: Check file (darwin)
-  shell: chdir={{workdir}} echo "`cat {{beat_pkg}}.sha512`  {{beat_pkg}}" | shasum -a 512 -c
+  shell: chdir={{workdir}} shasum -a 512 -c {{beat_pkg}}.sha512
   when: ansible_os_family == "Darwin"

--- a/roles/test-linux-binary/tasks/main.yml
+++ b/roles/test-linux-binary/tasks/main.yml
@@ -16,7 +16,7 @@
   get_url: url={{beat_url}} dest={{workdir}} validate_certs=no
 
 - name: Check file (linux)
-  shell: chdir={{workdir}} echo "`cat {{beat_pkg}}.sha512`  {{beat_pkg}}" | sha512sum -c
+  shell: chdir={{workdir}} sha512sum -c {{beat_pkg}}.sha512
 
 - name: Create install directory
   file: path={{installdir}} state=directory

--- a/run-settings-staging.yml
+++ b/run-settings-staging.yml
@@ -1,2 +1,2 @@
-url_base: https://staging.elastic.co/6.0.0-rc1-c8f2d2ee/downloads/beats
-version: 6.0.0-rc1
+url_base: https://staging.elastic.co/6.0.0-rc2-ba5a2827/downloads/beats
+version: 6.0.0-rc2


### PR DESCRIPTION
The format changed, so updating the tests. Also excluding log files via `.gitignore`.