### PR TITLE
Fix failing tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 # Directories
 /.vagrant
 /.idea
+/ve
 
 # Files
 .DS_Store

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ ANSIBLE_EXTRA_FLAGS?=
 
 # TODO (2018-01-22 andrewkroh): Remove this after Filebeat is fixed.
 # https://github.com/elastic/beats/issues/6145
-ANSIBLE_EXTRA_FLAGS=--skip-tags windows_filebeat
+ANSIBLE_EXTRA_FLAGS=--skip-tags filebeat
 
 # Create a virtualenv to run Ansible.
 ve: ve/bin/activate

--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,37 @@
+RUN_SETTINGS?=staging
+# Control ansible's verbosity by setting this with -v or -vvvvv (more verbose).
+ANSIBLE_VERBOSE?=
+# Exluding localhost, as localhost is assumed to be Mac OS X with ssh enabled.
+ANSIBLE_LIMIT?=all:!localhost
+# Extra flags to pass to Ansible (e.g. --skip-tags filebeat).
+ANSIBLE_EXTRA_FLAGS?=
 
+# TODO (2018-01-22 andrewkroh): Remove this after Filebeat is fixed.
+# https://github.com/elastic/beats/issues/6145
+ANSIBLE_EXTRA_FLAGS=--skip-tags windows_filebeat
+
+# Create a virtualenv to run Ansible.
+ve: ve/bin/activate
+ve/bin/activate: requirements.txt
+	@test -d ve || virtualenv ve
+	@ve/bin/pip install -Ur requirements.txt
+	@touch ve/bin/activate
+
+# Setup the VMs and the SSH config needed for Ansible to communicate to them.
 setup:
 	vagrant up
 	vagrant ssh-config > ssh_config
 
-# Run build based on RUN_SETTINGS name
-run: setup
-	# Exluding localhost, as localhost is assumed to be Mac OS X with ssh enabled
-	ansible-playbook -i hosts --ssh-extra-args '-F ssh_config' -e @run-settings-${RUN_SETTINGS}.yml --limit 'all:!localhost' site.yml
-
-1.1.0:
-	RUN_SETTINGS=1.1.0-latest make run
-
-1.2.0:
-	RUN_SETTINGS=1.2.0-latest make run
+# Run Ansible from the virtualenv.
+run: ve
+	ve/bin/ansible-playbook \
+	${ANSIBLE_VERBOSE} \
+	-i hosts \
+	--ssh-extra-args '-F ssh_config' \
+	-e @run-settings-${RUN_SETTINGS}.yml \
+	--limit "${ANSIBLE_LIMIT}" \
+	${ANSIBLE_EXTRA_FLAGS} \
+	site.yml
 
 # This destroys all vagrant machines and removes the vagrant related data
 clean:

--- a/README.md
+++ b/README.md
@@ -1,38 +1,51 @@
 # The Beats Tester
 
 Vagrant + Ansible setup for testing the OS packages and basic e2e tests for all
-the [Beats](https://www.elastic.co/products/beats)
+the [Beats](https://www.elastic.co/products/beats).
 
 
 ## Execute
 
 First, you need to bring the machines up:
 
-    vagrant up
-
-and make them known by name to SSH:
-
-    vagrant ssh-config >> ~/.ssh/config
+    make setup
 
 Then you can use Ansible to run the tests. Because they involve lots of VMs and
 commands executed over SSH, these tests are slow (currently 15 minutes in
-total). However, while creating tests or checking something quickly, you can
-use different Ansible commands to execute only a subset.
+total). However, while creating tests or checking something quickly, you can use
+different Ansible commands to execute only a subset.
 
 Here are some execution examples:
 
-* Test the most recent nightly builds (excluding OS X):
+* Test the most recent [nightly builds](https://internal-ci.elastic.co/job/elastic+release-manager+master+unified-snapshot/) (excluding OS X):
 
-        make nightlies
+        RUN_SETTINGS=snapshot make run
 
 * All tests, all platforms, a particular release:
 
-        ansible-playbook -i hosts -e @run-settings-1.0.0-beta3.yml site.yml
+        # Edit version contained in run-settings-released.yml.
+        RUN_SETTINGS=released make run
 
 * Only a particular Beat, Packetbeat in the example:
 
-        ansible-playbook -i hosts -e @run-settings-nightly.yml --tags packetbeat site.yml
+        export ANSIBLE_EXTRA_FLAGS="--tags packetbeat"
+        make run
 
 * Only a particular OS, Debian 6 amd64 in the example:
 
-        ansible-playbook -i hosts -e @run-settings-nightly.yml --limit tester-debian6-64 site.yml
+        # Instead using 'make setup' launch vagrant machines manually.
+        vagrant up tester-debian6-64
+        vagrant ssh-config > ssh_config
+        export ANSIBLE_LIMIT="tester-debian9-64"
+        make run
+
+* Enable Ansible debug.
+
+        export ANSIBLE_VERBOSE="-vvv"
+        make run
+
+## Cleanup
+
+You need to tear down the VMs when you are finished.
+
+    make clean

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -27,7 +27,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     end
 
     config.vm.define "tester-ubuntu1204-32" do |testvm|
-        testvm.vm.box = "hashicorp/precise32"
+        testvm.vm.box = "ubuntu/precise32"
 
         testvm.ssh.port = 2403
         testvm.vm.network "forwarded_port", guest: 22, host: testvm.ssh.port, host_ip: "127.0.0.1"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+ansible==2.4.2.0
+pywinrm>=0.2.2
+markupsafe

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -27,7 +27,7 @@
   set_fact:
     beat_url: "{{url_base}}/{{beat_name}}/{{beat_name}}-{{version}}-windows-{{win_arch}}.zip"
     beat_pkg: "{{beat_name}}-{{version}}-windows-{{win_arch}}.zip"
-    beat_cfg: c:\\users\\vagrant\\{{beat_name}}-{{version}}-windows\\{{beat_name}}.yml
+    beat_cfg: 'c:\users\vagrant\{{beat_name}}-{{version}}-windows-{{win_arch}}\{{beat_name}}.yml'
     workdir: c:\\users\\vagrant
     installdir: c:\\users\\vagrant\\{{beat_name}}-{{version}}-windows-{{win_arch}}
   when: ansible_os_family == "Windows"

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -32,7 +32,10 @@
     installdir: c:\\users\\vagrant\\{{beat_name}}-{{version}}-windows-{{win_arch}}
   when: ansible_os_family == "Windows"
 
-- debug: var=beat_cfg
+- name: Display all variables/facts known for a host
+  debug:
+    var: hostvars[inventory_hostname]
+    verbosity: 4
 
 # download packages and sha1 files
 - include: download.yml

--- a/roles/test-install/tasks/main.yml
+++ b/roles/test-install/tasks/main.yml
@@ -12,9 +12,18 @@
   apt: name={{service_name}} state=absent
   when: ansible_os_family == "Debian"
 
-- name: Install Debs
+- name: Install Debs (apt)
   apt: deb={{workdir}}/{{beat_pkg}} state=present
-  when: ansible_os_family == "Debian"
+  when:
+    - ansible_os_family == "Debian"
+    - ansible_distribution_major_version != "6"
+
+# XXX: Workaround for https://github.com/ansible/ansible/issues/31471.
+- name: Install Debs (dpkg)
+  command: dpkg -i {{workdir}}/{{beat_pkg}}
+  when:
+    - ansible_os_family == "Debian"
+    - ansible_distribution_major_version == "6"
 
 - name: Install RPMs
   yum: name={{workdir}}/{{beat_pkg}} state=present

--- a/roles/test-linux-binary/tasks/main.yml
+++ b/roles/test-linux-binary/tasks/main.yml
@@ -38,7 +38,7 @@
 
 - name: Sleep a little
   shell: sleep 1
-  always_run: true
+  check_mode: no
 
 - name: Curl something (linux)
   shell: wget google.com

--- a/roles/test-metricbeat-file/tasks/main.yml
+++ b/roles/test-metricbeat-file/tasks/main.yml
@@ -10,8 +10,9 @@
   when: ansible_os_family in ["Debian", "RedHat", "Suse"]
 
 - name: Start Metricbeat (darwin)
-  shell: chdir={{installdir}} ./{{beat_name}} -E output.elasticsearch.enabled=false -E output.file.path={{workdir}}/output -E metricbeat.max_start_delay=0s
-
+  shell: './{{ beat_name }} -E output.elasticsearch.enabled=false -E output.file.path={{ workdir }}/output -E metricbeat.max_start_delay=0s'
+  args:
+    chdir: '{{ installdir }}'
   when: ansible_os_family == "Darwin"
   async: 45
   poll: 0  # run in bg
@@ -19,4 +20,4 @@
 - name: Wait for the output file to be created, should contain cpu stats
   wait_for: >
     path={{workdir}}/output/metricbeat timeout=15
-    search_regex='"module":"system","name":"cpu"'
+    search_regex='"name":"cpu","module":"system"'

--- a/roles/test-packetbeat-file/tasks/main.yml
+++ b/roles/test-packetbeat-file/tasks/main.yml
@@ -18,17 +18,17 @@
 
 - name: Sleep a little for packetbeat to start
   shell: sleep 1
-  always_run: true
+  check_mode: no
 
 - name: Curl something (linux)
   shell: wget google.com
   when: ansible_os_family in ["Debian", "RedHat", "Suse"]
-  always_run: true
+  check_mode: no
 
 - name: Curl something (darwin)
   shell: curl -L google.com
   when: ansible_os_family == "Darwin"
-  always_run: true
+  check_mode: no
 
 - name: Wait for the output file to be created, should contain type=http
   wait_for: >

--- a/roles/test-win-filebeat-file/tasks/main.yml
+++ b/roles/test-win-filebeat-file/tasks/main.yml
@@ -5,7 +5,7 @@
   win_file: path=c:\windows\syswow64\.filebeat state=absent
 
 - name: Replace configuration file (windows)
-  win_copy: src={{beat_name}}.yml dest={{installdir}}
+  win_copy: src={{beat_name}}.yml dest='{{ beat_cfg }}'
 
 - name: Install Filebeat service
   script: run_script.ps1 -script {{installdir}}\\install-service-{{beat_name}}.ps1

--- a/roles/test-win-heartbeat-file/tasks/main.yml
+++ b/roles/test-win-heartbeat-file/tasks/main.yml
@@ -2,7 +2,7 @@
   win_file: path={{workdir}}\\output state=absent
 
 - name: Replace configuration file (windows)
-  win_copy: src={{beat_name}}.yml dest={{installdir}}
+  win_copy: src={{beat_name}}.yml dest='{{ beat_cfg }}'
 
 - name: Install service
   script: run_script.ps1 -script {{installdir}}\\install-service-{{beat_name}}.ps1

--- a/roles/test-win-metricbeat-file/tasks/main.yml
+++ b/roles/test-win-metricbeat-file/tasks/main.yml
@@ -2,7 +2,7 @@
   win_file: path={{workdir}}\\output state=absent
 
 - name: Replace configuration file (windows)
-  win_copy: src=metricbeat.yml dest={{installdir}}
+  win_copy: src=metricbeat.yml dest='{{ beat_cfg }}'
 
 - name: Install Metricbeat service
   script: run_script.ps1 -script {{installdir}}\\install-service-metricbeat.ps1

--- a/roles/test-win-packetbeat-file/tasks/main.yml
+++ b/roles/test-win-packetbeat-file/tasks/main.yml
@@ -2,7 +2,7 @@
   win_file: path={{workdir}}\\output state=absent
 
 - name: Replace configuration file (windows)
-  win_copy: src=packetbeat.yml dest={{installdir}}
+  win_copy: src=packetbeat.yml dest='{{ beat_cfg }}'
 
 - name: Install Packetbeat service
   script: run_script.ps1 -script {{installdir}}\\install-service-packetbeat.ps1
@@ -33,4 +33,3 @@
     that:
       - "output_stat.stat.exists"
       - "output_stat.stat.size > 800"
-

--- a/roles/test-win-winlogbeat-file/tasks/main.yml
+++ b/roles/test-win-winlogbeat-file/tasks/main.yml
@@ -5,7 +5,7 @@
   script: run_script.ps1 -script {{ installdir }}\\install-service-{{ beat_name }}.ps1
 
 - name: Replace configuration file with template (windows)
-  win_template: src={{beat_name}}.yml dest={{installdir}}
+  win_template: src={{beat_name}}.yml dest='{{ beat_cfg }}'
 
 - name: Start Winlogbeat
   win_service: name={{ beat_name }} state=started

--- a/run-nightlies.yml
+++ b/run-nightlies.yml
@@ -1,2 +1,0 @@
-url_base: https://snapshots.elastic.co/downloads/beats
-version: 7.0.0-alpha1-SNAPSHOT

--- a/run-settings-released.yml
+++ b/run-settings-released.yml
@@ -1,0 +1,3 @@
+# Released artifacts.
+url_base: https://artifacts.elastic.co/downloads/beats
+version:  6.1.2

--- a/run-settings-snapshot.yml
+++ b/run-settings-snapshot.yml
@@ -1,0 +1,4 @@
+# Snapshot builds.
+# Published by: https://internal-ci.elastic.co/job/elastic+release-manager+master+unified-snapshot/
+url_base: https://snapshots.elastic.co/downloads/beats
+version: 7.0.0-alpha1-SNAPSHOT

--- a/run-settings-staging.yml
+++ b/run-settings-staging.yml
@@ -1,2 +1,3 @@
-url_base: https://staging.elastic.co/6.0.0-rc2-ba5a2827/downloads/beats
-version: 6.0.0-rc2
+# Staged releases.
+url_base: https://staging.elastic.co/6.2.0-0557a3c6/downloads/beats
+version: 6.2.0

--- a/site.yml
+++ b/site.yml
@@ -137,7 +137,6 @@
   tags:
     - filebeat
     - windows
-    - windows_filebeat
   vars:
     - beat_name: filebeat
     - win_arch: x86
@@ -153,7 +152,6 @@
   tags:
     - filebeat
     - windows
-    - windows_filebeat
   vars:
     - beat_name: filebeat
     - win_arch: x86_64

--- a/site.yml
+++ b/site.yml
@@ -4,7 +4,7 @@
     - debian
     - centos
     - darwin
-  sudo: yes
+  become: yes
   tags:
     - packetbeat
   vars:
@@ -22,7 +22,7 @@
     - debian
     - centos
     - darwin
-  sudo: yes
+  become: yes
   tags:
     - filebeat
   vars:
@@ -39,7 +39,7 @@
     - debian
     - centos
     - darwin
-  sudo: yes
+  become: yes
   tags:
     - metricbeat
   vars:
@@ -56,7 +56,7 @@
     - debian
     - centos
     - darwin
-  sudo: yes
+  become: yes
   tags:
     - heartbeat
   vars:

--- a/site.yml
+++ b/site.yml
@@ -137,6 +137,7 @@
   tags:
     - filebeat
     - windows
+    - windows_filebeat
   vars:
     - beat_name: filebeat
     - win_arch: x86
@@ -152,6 +153,7 @@
   tags:
     - filebeat
     - windows
+    - windows_filebeat
   vars:
     - beat_name: filebeat
     - win_arch: x86_64


### PR DESCRIPTION
- Add virtualenv for running Ansible in a reproducible manner.
- Change regex for matching Metricbeat output from the system-cpu metricset

  The order of the JSON keys in the `metricset` object is different in the output than before (I haven't determined why.)

- Update the win_copy dest argument to include the file name and not just the destination directory.
- Refactor the Makefile and update the README.
- Temporarily disable Filebeat testing https://github.com/elastic/beats/issues/6145 is resolved.
- Fix deprecations (sudo -> become, always_run -> check_mode = no).
- Use ubuntu/precise32 instead of hashicorp/precise32. The hashicorp/precise32 is `ansible_os_family == Mandrake` and none of the Ansible roles handle Mandrake (they expect Debian).
- Add workaround for an Ansible issue on Debian 6. https://github.com/ansible/ansible/issues/31471