### PR TITLE
Re-enable windows filebeat tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,10 +6,6 @@ ANSIBLE_LIMIT?=all:!localhost
 # Extra flags to pass to Ansible (e.g. --skip-tags filebeat).
 ANSIBLE_EXTRA_FLAGS?=
 
-# TODO (2018-01-22 andrewkroh): Remove this after Filebeat is fixed.
-# https://github.com/elastic/beats/issues/6145
-ANSIBLE_EXTRA_FLAGS=--skip-tags filebeat
-
 # Create a virtualenv to run Ansible.
 ve: ve/bin/activate
 ve/bin/activate: requirements.txt


### PR DESCRIPTION
The bug leading to this tests being disabled ( elastic/beats#6145 ) is fixed now 

