### PR TITLE
Allow for different JSON order

### DIFF
--- a/roles/test-metricbeat-file/tasks/main.yml
+++ b/roles/test-metricbeat-file/tasks/main.yml
@@ -20,4 +20,4 @@
 - name: Wait for the output file to be created, should contain cpu stats
   wait_for: >
     path={{workdir}}/output/metricbeat timeout=15
-    search_regex='"name":"cpu","module":"system"'
+    search_regex='("name":"cpu","module":"system")|("module":"system","name":"cpu")'


### PR DESCRIPTION
The order was changed to reflect what happens in 6.2, but we still need
to test older releases (e.g 6.1.x), so changing the regexp to accept both
ways.