### PR TITLE
Check ephemeral ID of every Beat

### DIFF
--- a/roles/test-beat/tasks/common/assert.yml
+++ b/roles/test-beat/tasks/common/assert.yml
@@ -51,11 +51,25 @@
 - name: 'Get {{ beat_name }} metrics from logs'
   shell: 'grep "Total non-zero metrics" {{ beat_log_file }} | tail -1'
   register: log_metrics
-  when: ansible_system != "Win32NT"
 
 - set_fact: log_metrics_event='{{ log_metrics.stdout | from_json }}'
-  when: ansible_system != "Win32NT"
 
-- name: 'Check {{ beat_name }} has ephemeral ID'
+- name: 'Check {{ beat_name }} has monitoring metrics'
   assert:
-      that: "log_metrics_event.monitoring.metrics.beat.info.ephemeral_id"
+    that:
+      - "log_metrics_event.monitoring.metrics.beat.cpu.system.ticks >= 0"
+      - "log_metrics_event.monitoring.metrics.beat.cpu.system.time >= 0"
+      - "log_metrics_event.monitoring.metrics.beat.cpu.total.ticks >= 0"
+      - "log_metrics_event.monitoring.metrics.beat.cpu.total.time >= 0"
+      - "log_metrics_event.monitoring.metrics.beat.cpu.total.value >= 0"
+      - "log_metrics_event.monitoring.metrics.beat.cpu.user.ticks >= 0"
+      - "log_metrics_event.monitoring.metrics.beat.cpu.user.time >= 0"
+      - "log_metrics_event.monitoring.metrics.beat.info.ephemeral_id"
+      - "log_metrics_event.monitoring.metrics.beat.info.uptime.ms"
+      - "log_metrics_event.monitoring.metrics.system.cpu.cores"
+      - "'1' in log_metrics_event.monitoring.metrics.system.load"
+      - "'15' in log_metrics_event.monitoring.metrics.system.load"
+      - "'5' in log_metrics_event.monitoring.metrics.system.load"
+      - "'1' in log_metrics_event.monitoring.metrics.system.load.norm"
+      - "'15' in log_metrics_event.monitoring.metrics.system.load.norm"
+      - "'5' in log_metrics_event.monitoring.metrics.system.load.norm"

--- a/roles/test-beat/tasks/common/assert.yml
+++ b/roles/test-beat/tasks/common/assert.yml
@@ -47,3 +47,15 @@
       - "registry_stat.stat.exists"
       - "registry_stat.stat.size > 0"
   when: registry_file != ''
+
+- name: 'Get {{ beat_name }} metrics from logs'
+  shell: 'grep "Total non-zero metrics" {{ beat_log_file }} | tail -1'
+  register: log_metrics
+  when: ansible_system != "Win32NT"
+
+- set_fact: log_metrics_event='{{ log_metrics.stdout | from_json }}'
+  when: ansible_system != "Win32NT"
+
+- name: 'Check {{ beat_name }} has ephemeral ID'
+  assert:
+      that: "log_metrics_event.monitoring.metrics.beat.info.ephemeral_id"

--- a/roles/test-beat/tasks/win32nt/assert.yml
+++ b/roles/test-beat/tasks/win32nt/assert.yml
@@ -47,3 +47,17 @@
       - "registry_stat.stat.exists"
       - "registry_stat.stat.size > 0"
   when: registry_file != ''
+
+- name: 'Get {{ beat_name }} metrics from logs (win)'
+  win_shell: 'cat -Encoding UTF8 {{ beat_log_file }} |
+      select-string -Encoding UTF8 "Total non-zero" |
+      Select -Expandproperty Line | select -First 1'
+  register: log_metrics_win
+  when: ansible_system == "Win32NT"
+
+- set_fact: log_metrics_event='{{ log_metrics_win.stdout | from_json }}'
+  when: ansible_system == "Win32NT"
+
+- name: 'Check {{ beat_name }} has ephemeral ID (win)'
+  assert:
+      that: "log_metrics_event.monitoring.metrics.beat.info.ephemeral_id"

--- a/roles/test-beat/tasks/win32nt/assert.yml
+++ b/roles/test-beat/tasks/win32nt/assert.yml
@@ -53,11 +53,25 @@
       select-string -Encoding UTF8 "Total non-zero" |
       Select -Expandproperty Line | select -First 1'
   register: log_metrics_win
-  when: ansible_system == "Win32NT"
 
 - set_fact: log_metrics_event='{{ log_metrics_win.stdout | from_json }}'
-  when: ansible_system == "Win32NT"
 
-- name: 'Check {{ beat_name }} has ephemeral ID (win)'
+- name: 'Check {{ beat_name }} has monitoring metrics (win)'
   assert:
-      that: "log_metrics_event.monitoring.metrics.beat.info.ephemeral_id"
+    that:
+      - "log_metrics_event.monitoring.metrics.beat.cpu.system.ticks >= 0"
+      - "log_metrics_event.monitoring.metrics.beat.cpu.system.time >= 0"
+      - "log_metrics_event.monitoring.metrics.beat.cpu.total.ticks >= 0"
+      - "log_metrics_event.monitoring.metrics.beat.cpu.total.time >= 0"
+      - "log_metrics_event.monitoring.metrics.beat.cpu.user.ticks >= 0"
+      - "log_metrics_event.monitoring.metrics.beat.cpu.user.time >= 0"
+      - "log_metrics_event.monitoring.metrics.beat.info.ephemeral_id"
+      - "log_metrics_event.monitoring.metrics.beat.info.uptime.ms"
+      - "log_metrics_event.monitoring.metrics.system.cpu.cores"
+    not:
+      - "log_metrics_event.monitoring.metrics.system.cpu.load.1"
+      - "log_metrics_event.monitoring.metrics.system.cpu.load.5"
+      - "log_metrics_event.monitoring.metrics.system.cpu.load.15"
+      - "log_metrics_event.monitoring.metrics.system.cpu.load.norm.1"
+      - "log_metrics_event.monitoring.metrics.system.cpu.load.norm.5"
+      - "log_metrics_event.monitoring.metrics.system.cpu.load.norm.15"


### PR DESCRIPTION
This PR includes assertions which check if a Beat has an ephemeral ID in its monitoring event.
If a Beat has an ephemeral ID, it can be shown in XPack Monitoring. (It's still possible that some metrics are not available, due to the lack of CGO.)

Required by https://github.com/elastic/beats/pull/6501