### PR TITLE
Follow up metrics renames in monitoring events && add debug messages

### DIFF
--- a/roles/test-beat/tasks/common/assert.yml
+++ b/roles/test-beat/tasks/common/assert.yml
@@ -54,16 +54,20 @@
 
 - set_fact: log_metrics_event='{{ log_metrics.stdout | from_json }}'
 
+- name: '{{ beat_name }} monitoring metrics'
+  debug:
+    var: log_metrics_event
+
 - name: 'Check {{ beat_name }} has monitoring metrics'
   assert:
     that:
       - "log_metrics_event.monitoring.metrics.beat.cpu.system.ticks >= 0"
-      - "log_metrics_event.monitoring.metrics.beat.cpu.system.time >= 0"
+      - "log_metrics_event.monitoring.metrics.beat.cpu.system.time.ms >= 0"
       - "log_metrics_event.monitoring.metrics.beat.cpu.total.ticks >= 0"
-      - "log_metrics_event.monitoring.metrics.beat.cpu.total.time >= 0"
+      - "log_metrics_event.monitoring.metrics.beat.cpu.total.time.ms >= 0"
       - "log_metrics_event.monitoring.metrics.beat.cpu.total.value >= 0"
       - "log_metrics_event.monitoring.metrics.beat.cpu.user.ticks >= 0"
-      - "log_metrics_event.monitoring.metrics.beat.cpu.user.time >= 0"
+      - "log_metrics_event.monitoring.metrics.beat.cpu.user.time.ms >= 0"
       - "log_metrics_event.monitoring.metrics.beat.info.ephemeral_id"
       - "log_metrics_event.monitoring.metrics.beat.info.uptime.ms"
       - "log_metrics_event.monitoring.metrics.system.cpu.cores"

--- a/roles/test-beat/tasks/win32nt/assert.yml
+++ b/roles/test-beat/tasks/win32nt/assert.yml
@@ -56,15 +56,19 @@
 
 - set_fact: log_metrics_event='{{ log_metrics_win.stdout | from_json }}'
 
+- name: '{{ beat_name }} monitoring metrics (win)'
+  debug:
+    var: log_metrics_event
+
 - name: 'Check {{ beat_name }} has monitoring metrics (win)'
   assert:
     that:
       - "log_metrics_event.monitoring.metrics.beat.cpu.system.ticks >= 0"
-      - "log_metrics_event.monitoring.metrics.beat.cpu.system.time >= 0"
+      - "log_metrics_event.monitoring.metrics.beat.cpu.system.time.ms >= 0"
       - "log_metrics_event.monitoring.metrics.beat.cpu.total.ticks >= 0"
-      - "log_metrics_event.monitoring.metrics.beat.cpu.total.time >= 0"
+      - "log_metrics_event.monitoring.metrics.beat.cpu.total.time.ms >= 0"
       - "log_metrics_event.monitoring.metrics.beat.cpu.user.ticks >= 0"
-      - "log_metrics_event.monitoring.metrics.beat.cpu.user.time >= 0"
+      - "log_metrics_event.monitoring.metrics.beat.cpu.user.time.ms >= 0"
       - "log_metrics_event.monitoring.metrics.beat.info.ephemeral_id"
       - "log_metrics_event.monitoring.metrics.beat.info.uptime.ms"
       - "log_metrics_event.monitoring.metrics.system.cpu.cores"


### PR DESCRIPTION
A few metrics were renamed in https://github.com/elastic/beats/pull/6449
This PR follows up the changes in counter names.

I also added debug "messages", so it's visible if something is missing from the event.

@andrewkroh Is it possible to run this branch in Jenkins before merging it?