### PR TITLE
Use /stats to fetch metrics instead of logs

### DIFF
--- a/roles/test-beat/tasks/common/assert.yml
+++ b/roles/test-beat/tasks/common/assert.yml
@@ -48,8 +48,8 @@
       - "registry_stat.stat.size > 0"
   when: registry_file != ''
 
-- name: 'Get {{ beat_name }} metrics from logs'
-  shell: 'grep "Total non-zero metrics" {{ beat_log_file }} | tail -1'
+- name: 'Get {{ beat_name }} metrics'
+  shell: 'head -1 {{ beat_metrics_file }}'
   register: log_metrics
 
 - set_fact: log_metrics_event='{{ log_metrics.stdout | from_json }}'
@@ -61,19 +61,19 @@
 - name: 'Check {{ beat_name }} has monitoring metrics'
   assert:
     that:
-      - "log_metrics_event.monitoring.metrics.beat.cpu.system.ticks >= 0"
-      - "log_metrics_event.monitoring.metrics.beat.cpu.system.time.ms >= 0"
-      - "log_metrics_event.monitoring.metrics.beat.cpu.total.ticks >= 0"
-      - "log_metrics_event.monitoring.metrics.beat.cpu.total.time.ms >= 0"
-      - "log_metrics_event.monitoring.metrics.beat.cpu.total.value >= 0"
-      - "log_metrics_event.monitoring.metrics.beat.cpu.user.ticks >= 0"
-      - "log_metrics_event.monitoring.metrics.beat.cpu.user.time.ms >= 0"
-      - "log_metrics_event.monitoring.metrics.beat.info.ephemeral_id"
-      - "log_metrics_event.monitoring.metrics.beat.info.uptime.ms"
-      - "log_metrics_event.monitoring.metrics.system.cpu.cores"
-      - "'1' in log_metrics_event.monitoring.metrics.system.load"
-      - "'15' in log_metrics_event.monitoring.metrics.system.load"
-      - "'5' in log_metrics_event.monitoring.metrics.system.load"
-      - "'1' in log_metrics_event.monitoring.metrics.system.load.norm"
-      - "'15' in log_metrics_event.monitoring.metrics.system.load.norm"
-      - "'5' in log_metrics_event.monitoring.metrics.system.load.norm"
+      - "log_metrics_event.beat.cpu.system.ticks >= 0"
+      - "log_metrics_event.beat.cpu.system.time.ms >= 0"
+      - "log_metrics_event.beat.cpu.total.ticks >= 0"
+      - "log_metrics_event.beat.cpu.total.time.ms >= 0"
+      - "log_metrics_event.beat.cpu.total.value >= 0"
+      - "log_metrics_event.beat.cpu.user.ticks >= 0"
+      - "log_metrics_event.beat.cpu.user.time.ms >= 0"
+      - "log_metrics_event.beat.info.ephemeral_id"
+      - "log_metrics_event.beat.info.uptime.ms"
+      - "log_metrics_event.system.cpu.cores"
+      - "'1' in log_metrics_event.system.load"
+      - "'15' in log_metrics_event.system.load"
+      - "'5' in log_metrics_event.system.load"
+      - "'1' in log_metrics_event.system.load.norm"
+      - "'15' in log_metrics_event.system.load.norm"
+      - "'5' in log_metrics_event.system.load.norm"

--- a/roles/test-beat/tasks/darwin/main.yml
+++ b/roles/test-beat/tasks/darwin/main.yml
@@ -51,3 +51,9 @@
     path: '{{ beat_output_file }}'
     search_regex: '"version"'
     timeout: 20
+
+- name: 'Fetch metrics from {{ beat_name }} over HTTP'
+  get_url:
+    url: http://localhost:5066/stats
+    dest: '{{ beat_metrics_file }}'
+    force: yes

--- a/roles/test-beat/tasks/linux/main.yml
+++ b/roles/test-beat/tasks/linux/main.yml
@@ -45,6 +45,12 @@
     search_regex: '"version"'
     timeout: 20
 
+- name: 'Fetch metrics from {{ beat_name }} over HTTP'
+  get_url:
+    url: http://localhost:5066/stats
+    dest: '{{ beat_metrics_file }}'
+    force: yes
+
 - name: "Stop {{ beat_service_name }} service"
   service:
     name: '{{ beat_service_name }}'

--- a/roles/test-beat/tasks/main.yml
+++ b/roles/test-beat/tasks/main.yml
@@ -28,6 +28,7 @@
     beat_output_file: '{{ beat_logs_path }}/output.json'
     beat_log_file: '{{ beat_logs_path }}/{{ beat_name }}.json'
     beat_registry_file: '{{ beat_data_path }}/{{ registry_file }}'
+    beat_metrics_file: '{{ beat_logs_path }}/metrics.json'
 
 - name: 'Display vars for testing {{ beat_name }}'
   debug:
@@ -70,6 +71,12 @@
       dest: 'logs/{{ beat_name }}-{{ win_arch | default(ansible_architecture) }}-{{ inventory_hostname }}/{{ registry_file }}'
       flat: yes
     when: registry_file != ''
+
+  - name: Save metrics to host
+    fetch:
+      src: '{{ beat_metrics_file }}'
+      dest: 'logs/{{ beat_name }}-{{ win_arch | default(ansible_architecture) }}-{{ inventory_hostname }}/metrics.json'
+      flat: yes
 ##### BLOCK END
 
 - name: Run assertions on outputs

--- a/roles/test-beat/tasks/win32nt/assert.yml
+++ b/roles/test-beat/tasks/win32nt/assert.yml
@@ -48,10 +48,8 @@
       - "registry_stat.stat.size > 0"
   when: registry_file != ''
 
-- name: 'Get {{ beat_name }} metrics from logs (win)'
-  win_shell: 'cat -Encoding UTF8 {{ beat_log_file }} |
-      select-string -Encoding UTF8 "Total non-zero" |
-      Select -Expandproperty Line | select -First 1'
+- name: 'Get {{ beat_name }} metrics (win)'
+  win_shell: 'cat -Encoding UTF8 {{ beat_metrics_file }} | select -First 1'
   register: log_metrics_win
 
 - set_fact: log_metrics_event='{{ log_metrics_win.stdout | from_json }}'
@@ -63,19 +61,14 @@
 - name: 'Check {{ beat_name }} has monitoring metrics (win)'
   assert:
     that:
-      - "log_metrics_event.monitoring.metrics.beat.cpu.system.ticks >= 0"
-      - "log_metrics_event.monitoring.metrics.beat.cpu.system.time.ms >= 0"
-      - "log_metrics_event.monitoring.metrics.beat.cpu.total.ticks >= 0"
-      - "log_metrics_event.monitoring.metrics.beat.cpu.total.time.ms >= 0"
-      - "log_metrics_event.monitoring.metrics.beat.cpu.user.ticks >= 0"
-      - "log_metrics_event.monitoring.metrics.beat.cpu.user.time.ms >= 0"
-      - "log_metrics_event.monitoring.metrics.beat.info.ephemeral_id"
-      - "log_metrics_event.monitoring.metrics.beat.info.uptime.ms"
-      - "log_metrics_event.monitoring.metrics.system.cpu.cores"
+      - "log_metrics_event.beat.cpu.system.ticks >= 0"
+      - "log_metrics_event.beat.cpu.system.time.ms >= 0"
+      - "log_metrics_event.beat.cpu.total.ticks >= 0"
+      - "log_metrics_event.beat.cpu.total.time.ms >= 0"
+      - "log_metrics_event.beat.cpu.user.ticks >= 0"
+      - "log_metrics_event.beat.cpu.user.time.ms >= 0"
+      - "log_metrics_event.beat.info.ephemeral_id"
+      - "log_metrics_event.beat.info.uptime.ms"
+      - "log_metrics_event.system.cpu.cores"
     not:
-      - "log_metrics_event.monitoring.metrics.system.cpu.load.1"
-      - "log_metrics_event.monitoring.metrics.system.cpu.load.5"
-      - "log_metrics_event.monitoring.metrics.system.cpu.load.15"
-      - "log_metrics_event.monitoring.metrics.system.cpu.load.norm.1"
-      - "log_metrics_event.monitoring.metrics.system.cpu.load.norm.5"
-      - "log_metrics_event.monitoring.metrics.system.cpu.load.norm.15"
+      - "log_metrics_event.system.cpu.load"

--- a/roles/test-beat/tasks/win32nt/main.yml
+++ b/roles/test-beat/tasks/win32nt/main.yml
@@ -41,6 +41,12 @@
 - name: "Let {{ beat_name }} run for 10s"
   win_shell: Start-Sleep -s 10
 
+- name: 'Fetch metrics from {{ beat_name }} over HTTP'
+  win_get_url:
+    url: http://localhost:5066/stats
+    dest: '{{ beat_metrics_file }}'
+    force: yes
+
 - name: "Stop {{ beat_name }} Windows service"
   win_service:
     name: '{{ beat_name }}'

--- a/roles/test-beat/templates/auditbeat.yml.j2
+++ b/roles/test-beat/templates/auditbeat.yml.j2
@@ -39,3 +39,5 @@ logging:
   json: true
   files:
     name: {{ beat_name }}.json
+
+http.host: localhost

--- a/roles/test-beat/templates/filebeat.yml.j2
+++ b/roles/test-beat/templates/filebeat.yml.j2
@@ -13,3 +13,5 @@ logging:
   json: true
   files:
     name: {{ beat_name }}.json
+
+http.host: localhost

--- a/roles/test-beat/templates/heartbeat.yml.j2
+++ b/roles/test-beat/templates/heartbeat.yml.j2
@@ -14,3 +14,5 @@ logging:
   json: true
   files:
     name: {{ beat_name }}.json
+
+http.host: localhost

--- a/roles/test-beat/templates/metricbeat.yml.j2
+++ b/roles/test-beat/templates/metricbeat.yml.j2
@@ -16,3 +16,5 @@ logging:
   json: true
   files:
     name: {{ beat_name }}.json
+
+http.host: localhost

--- a/roles/test-beat/templates/packetbeat.yml.j2
+++ b/roles/test-beat/templates/packetbeat.yml.j2
@@ -15,3 +15,5 @@ logging:
   json: true
   files:
     name: {{ beat_name }}.json
+
+http.host: localhost

--- a/roles/test-beat/templates/winlogbeat.yml.j2
+++ b/roles/test-beat/templates/winlogbeat.yml.j2
@@ -10,3 +10,5 @@ logging:
   json: true
   files:
     name: {{ beat_name }}.json
+
+http.host: localhost


### PR DESCRIPTION
Instead of using the "Total non-zero metrics" log lines use the HTTP /stats endpoint to fetch metrics. The main benefit is that zero value metrics are not filtered. This allows the tests to assert that the metrics actually exist.

A side-effect of not using logs is that we lose a check that the beat truly shut down. We should add another assertion to check for "\<beatname\> stopped." in the logs.

// cc: @kvch FYI re https://github.com/elastic/beats-tester/pull/74#issuecomment-373073675