### PR TITLE
Add conditionals based on beat version

### DIFF
--- a/roles/test-beat/tasks/common/assert.yml
+++ b/roles/test-beat/tasks/common/assert.yml
@@ -77,3 +77,5 @@
       - "'1' in log_metrics_event.system.load.norm"
       - "'15' in log_metrics_event.system.load.norm"
       - "'5' in log_metrics_event.system.load.norm"
+  # These metric names were established in 6.3.
+  when: "version | version_compare('6.3', '>=')"

--- a/roles/test-beat/tasks/win32nt/assert.yml
+++ b/roles/test-beat/tasks/win32nt/assert.yml
@@ -72,3 +72,5 @@
       - "log_metrics_event.system.cpu.cores"
     not:
       - "log_metrics_event.system.cpu.load"
+  # These metric names were established in 6.3.
+  when: "version | version_compare('6.3', '>=')"

--- a/site.yml
+++ b/site.yml
@@ -79,11 +79,18 @@
   vars:
     - beat_name: auditbeat
   roles:
-    - common
-    - test-install
-    - test-beat
-    - test-uninstall
-    - {role: test-linux-binary, when: ansible_system == "Linux"}
+    # The tests are written for Auditbeat 6.2 GA.
+    - role: common
+      when: "version | version_compare('6.2', '>=')"
+    - role: test-install
+      when: "version | version_compare('6.2', '>=')"
+    - role: test-beat
+      when: "version | version_compare('6.2', '>=')"
+    - role: test-uninstall
+      when: "version | version_compare('6.2', '>=')"
+    - role: test-linux-binary
+      when: ansible_system == "Linux"
+
 
 # windows
 - name: Packaging windows x86 tests for Packetbeat


### PR DESCRIPTION
- Run detailed auditbeat tests on >= 6.2 (where Auditbeat was made GA). The basic smoke test is still run for earlier releases.
- Run monitoring metric assertions on >= 6.3.