### PR TITLE
Update snapshot download URL to GCS bucket

### DIFF
--- a/run-settings-nightlies.yml
+++ b/run-settings-nightlies.yml
@@ -1,4 +1,4 @@
 # Beats "nightly" build artifacts.
 # Published by: https://beats-ci.elastic.co/job/elastic+beats+master+package/
-url_base: https://s3-us-west-2.amazonaws.com/beats-package-snapshots
+url_base: https://storage.cloud.google.com/beats-ci-artifacts/snapshots
 version: 7.0.0-alpha1-SNAPSHOT


### PR DESCRIPTION
With the migration of beats-ci to GCP, we've started pushing these artifacts into a GCS bucket instead of S3.