### PR TITLE
Use the publicly readable URL for snapshot downloads

### DIFF
--- a/run-settings-nightlies.yml
+++ b/run-settings-nightlies.yml
@@ -1,4 +1,4 @@
 # Beats "nightly" build artifacts.
 # Published by: https://beats-ci.elastic.co/job/elastic+beats+master+package/
-url_base: https://storage.cloud.google.com/beats-ci-artifacts/snapshots
+url_base: https://storage.googleapis.com/beats-ci-artifacts/snapshots
 version: 7.0.0-alpha1-SNAPSHOT


### PR DESCRIPTION
The old `https://storage.cloud.google.com/[BUCKET_NAME]/[OBJECT_NAME]` URL structure is what allows for access control, so it requires authentication with a Google account in order to generate temporary/expiring links (even for public objects).

The new `https://storage.googleapis.com/[BUCKET_NAME]/[OBJECT_NAME]` URL structure should work for public objects without requiring authentication.

See: https://cloud.google.com/storage/docs/collaboration#browser