### PR TITLE
Remove assertion beat field from Packetbeat

### DIFF
--- a/roles/test-beat/tasks/packetbeat/assert.yml
+++ b/roles/test-beat/tasks/packetbeat/assert.yml
@@ -25,4 +25,3 @@
       - "'@timestamp' in http_event"
       - "'@metadata' in http_event"
       - "'http' in http_event"
-      - "'beat' in http_event"


### PR DESCRIPTION
Only the Packetbeat tests were checking for the presence of the
`beat` field. In 7.0 that field is changing to `agent` so let's
just remove that check. If we need it we can add it back in a
common location that will apply to all Beats.