### PR TITLE
Update Filebeat config to remove filebeat.prospectors

### DIFF
--- a/roles/test-beat/templates/filebeat.yml.j2
+++ b/roles/test-beat/templates/filebeat.yml.j2
@@ -3,7 +3,7 @@
 filebeat.config.modules:
   path: ${path.config}/modules.d/*.yml
 
-filebeat.prospectors:
+filebeat.inputs:
 - paths:
   - '{{ filebeat_logs_dir }}/*.log'
 


### PR DESCRIPTION
The error was:

    Exiting: 1 error: setting 'filebeat.prospectors' has been removed

`prospectors` was deprecated in 6.3 and replaced with `inputs`. In 7.0 it
cannot be used.