### PR TITLE
Override BEAT_LOG_OPTS in systemd unit file

### DIFF
--- a/roles/test-beat/tasks/linux/main.yml
+++ b/roles/test-beat/tasks/linux/main.yml
@@ -25,6 +25,18 @@
     dest: '{{ beat_cfg }}'
     mode: 0600
 
+- name: Create dir for systemd overrides
+  file:
+    path: '/etc/systemd/system/{{ beat_service_name }}.service.d'
+    state: directory
+    mode: 0755
+
+- name: Override log options for systemd to get a log file
+  template:
+    src: systemd.debug.conf
+    dest: '/etc/systemd/system/{{ beat_service_name }}.service.d/debug.conf'
+    mode: 0600
+
 - name: 'Start {{ beat_service_name }} service'
   service:
     name: '{{ beat_service_name }}'

--- a/roles/test-beat/templates/systemd.debug.conf
+++ b/roles/test-beat/templates/systemd.debug.conf
@@ -1,0 +1,2 @@
+[Service]
+Environment="BEAT_LOG_OPTS="


### PR DESCRIPTION
This overrides the defaults in the unit file for out services so that we get a log file. The tests currently assert that the log exists.

We could extend the tests to assert that logs are written to journald in the future.

Relates to https://github.com/elastic/beats/pull/8942