### PR TITLE
Remove debian6, Add debian8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-RUN_SETTINGS?=staging
+RUN_SETTINGS?=nightlies
 # Control ansible's verbosity by setting this with -v or -vvvvv (more verbose).
 ANSIBLE_VERBOSE?=
 # Exluding localhost, as localhost is assumed to be Mac OS X with ssh enabled.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -36,9 +36,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   end
 
 
-  config.vm.define "tester-debian6-64" do |testvm|
-    testvm.vm.box = "debian64"
-    testvm.vm.box_url = "https://s3.amazonaws.com/beats-files/vagrant/beats-debian6-virtualbox.box"
+  config.vm.define "tester-debian8-64" do |testvm|
+    config.vm.box = "debian/jessie64"
 
     testvm.ssh.port = 2404
     testvm.vm.network "forwarded_port", guest: 22, host: testvm.ssh.port, host_ip: "127.0.0.1"

--- a/hosts
+++ b/hosts
@@ -3,7 +3,7 @@ tester-es
 
 [debian]
 tester-ubuntu1204-32
-tester-debian6-64
+tester-debian8-64
 tester-ubuntu1604-64
 tester-debian9-64
 


### PR DESCRIPTION
debian6 (squeeze) is no on our support matrix for Beats so remove it.

debian8 (jessie) is on the support matrix so add it.

Fixes #100