### PR TITLE
Test auditbeat system module in 7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,10 @@ Here are some execution examples:
         export ANSIBLE_EXTRA_FLAGS="--tags packetbeat"
         make run
 
-* Only a particular OS, Debian 6 amd64 in the example:
+* Only a particular OS, Debian 8 amd64 in the example:
 
         # Instead using 'make setup' launch vagrant machines manually.
-        machine=tester-debian6-64
+        machine=tester-debian8-64
         vagrant up $machine
         vagrant ssh-config $machine > ssh_config
         export ANSIBLE_LIMIT="$machine"

--- a/roles/test-beat/templates/auditbeat.yml.j2
+++ b/roles/test-beat/templates/auditbeat.yml.j2
@@ -30,6 +30,20 @@ auditbeat.modules:
   paths:
   - '{{ ansible_user_dir }}'
 
+{% if "oss" not in beat_pkg_suffix %}
+{% if version is version_compare('7.0', '>=') %}
+- module: system
+  metricsets:
+    - host
+    - process
+{% if ansible_system == "Linux" %}
+    - socket
+    - user
+  user.detect_password_changes: true
+{% endif %}
+{% endif %}
+{% endif %}
+
 output.file:
   path: '${path.logs}'
   filename: output.json


### PR DESCRIPTION
Enable all metricsets on Linux and only [host, process] on non-Linux.

This does not add any assertions as to the behavior of the module. So this will only
verify that Auditbeat actually runs with the module enabled. Some detailed assertions
can be added later.