### PR TITLE
Test auditbeat system module on >= 6.6

### DIFF
--- a/roles/test-beat/templates/auditbeat.yml.j2
+++ b/roles/test-beat/templates/auditbeat.yml.j2
@@ -31,7 +31,7 @@ auditbeat.modules:
   - '{{ ansible_user_dir }}'
 
 {% if "oss" not in beat_pkg_suffix %}
-{% if version is version_compare('7.0', '>=') %}
+{% if version is version_compare('6.6', '>=') %}
 - module: system
   metricsets:
     - host


### PR DESCRIPTION
We had a >= 7.0 version restriction on the system module config, but it's available in >= 6.6.