### PR TITLE
Check that Beat ships with the right binary

### DIFF
--- a/roles/test-beat/tasks/common/assert.yml
+++ b/roles/test-beat/tasks/common/assert.yml
@@ -96,3 +96,35 @@
   when:
     - "version | version_compare('6.5', '>=')"
     - ansible_system == "Linux"
+
+- name: 'Get {{ beat_name }} help output for an unknown help topic'
+  shell: '{{ beat_name }} help non_existing_topic'
+  register: test_cmd_result
+
+- name: 'Check that {{ beat_name }} reports unknown help topics'
+  assert:
+    that:
+      - "'Unknown help topic [`non_existing_topic`]' in test_cmd_result.stderr"
+
+- name: 'Get {{ beat_name }} help output for an X-Pack feature'
+  shell: '{{ beat_name }} help enroll'
+  register: xpack_cmd_result
+  # The enroll command appeared in 6.5.
+  when:
+      - "version | version_compare('6.5', '>=')"
+
+- name: 'Check that {{ beat_name }} contains X-Pack features'
+  assert:
+    that:
+      - "'Unknown help topic' not in xpack_cmd_result.stderr"
+  when:
+    - "version | version_compare('6.5', '>=')"
+    - 'beat_pkg_suffix == ""'
+
+- name: 'Check that {{ beat_name }} contains OSS features only'
+  assert:
+    that:
+      - "'Unknown help topic [`enroll`]' in xpack_cmd_result.stderr"
+  when:
+    - "version | version_compare('6.5', '>=')"
+    - 'beat_pkg_suffix != ""'

--- a/roles/test-beat/tasks/common/assert.yml
+++ b/roles/test-beat/tasks/common/assert.yml
@@ -119,7 +119,7 @@
       - "'Unknown help topic' not in xpack_cmd_result.stderr"
   when:
     - "version | version_compare('6.5', '>=')"
-    - 'beat_pkg_suffix == ""'
+    - "'oss' not in beat_pkg_suffix"
 
 - name: 'Check that {{ beat_name }} contains OSS features only'
   assert:
@@ -127,4 +127,4 @@
       - "'Unknown help topic [`enroll`]' in xpack_cmd_result.stderr"
   when:
     - "version | version_compare('6.5', '>=')"
-    - 'beat_pkg_suffix != ""'
+    - "'oss' in beat_pkg_suffix"


### PR DESCRIPTION
New check for all beats:
  - If package is oss: checks that help enroll fails.
  - If package is x-pack: check that help enroll doesn't fail.

This test is put to prevent cases where the wrong binary is packaged (i.e. the oss binary in the x-pack distribution).

Test only works on 6.5+ due to the enroll command being first available in v6.5.0.