### PR TITLE
Fix Linux package install and uninstall

### DIFF
--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -1,2 +1,2 @@
 service_name:  '{{ beat_name }}'
-beat_pkg_name: '{{ service_name }}{{ beat_pkg_suffix }}'
+beat_pkg_name: '{{ service_name }}'

--- a/roles/test-install/tasks/main.yml
+++ b/roles/test-install/tasks/main.yml
@@ -30,7 +30,7 @@
   when: ansible_os_family == "RedHat"
 
 - name: Install RPMs
-  zypper: name={{workdir}}/{{beat_pkg}} state=present disable_gpg_check=yes
+  command: rpm -i {{workdir}}/{{beat_pkg}}
   when: ansible_os_family == "Suse"
 
 - name: Untar (darwin)


### PR DESCRIPTION
This PR includes two fixes to RPM/DEB install and uninstall:

- OSS Beat is never uninstalled when testing Linux packages. 

  Uninstall of Beats packages are performed using `{beat_name}-oss` as package name.

  However, both the Elastic and OSS distributions of Beats use {beat_name} as the package name. The `-oss` prefix is not used neither in DEB nor in RPM packages.

- Installation of the OSS package under Suse installs the wrong package due to zypper peculiarities.

  Zypper, Suse's package manager, has some funny behavior when asked to install an RPM file. Instead of installing it, it will read its package name and version and then fetch the package from one of its repos.

  As {beatname}-oss.rpm uses {beatname} as internal package name, trying to install an OSS rpm file will result in the non-OSS package being installed from one of the repos or the cache:

```
opensuse-leap-42:~ # zypper --non-interactive --no-gpg-checks install /root/packetbeat-oss-7.0.0-SNAPSHOT-x86_64.rpm
Loading repository data...
Warning: Repository 'openSUSE-Leap-42.2-Update' appears to be outdated. Consider using a different mirror or server.
Warning: Repository 'openSUSE-Leap-42.2-Update-Non-Oss' appears to be outdated. Consider using a different mirror or server.
Reading installed packages...
Resolving package dependencies...

The following NEW package is going to be installed:
  packetbeat

1 new package to install.
Overall download size: 13.1 MiB. Already cached: 0 B. After the operation, additional 42.3 MiB will be used.
Continue? [y/n/? shows all options] (y): y
Retrieving package packetbeat-7.0.0-1.x86_64                                                                                                      (1/1),  13.1 MiB ( 42.3 MiB unpacked)
packetbeat-7.0.0-SNAPSHOT-x86_64.rpm:
    Header V4 RSA/SHA512 Signature, key ID d88e42b4: NOKEY
    V4 RSA/SHA512 Signature, key ID d88e42b4: NOKEY
packetbeat-7.0.0-1.x86_64 (Plain RPM files cache): Signature verification failed [4-Signatures public key is not available]
Accepting package despite the error. (--no-gpg-checks)

Checking for file conflicts: ....................................................................................................................................................[done]
(1/1) Installing: packetbeat-7.0.0-1.x86_64 .....................................................................................................................................[done]
Additional rpm output:
warning: /var/cache/zypp/packages/_tmpRPMcache_/packetbeat-7.0.0-SNAPSHOT-x86_64.rpm: Header V4 RSA/SHA512 Signature, key ID d88e42b4: NOKEY
```