### PR TITLE
Auditbeat System module: Change metricsets to datasets

### DIFF
--- a/roles/test-beat/templates/auditbeat.yml.j2
+++ b/roles/test-beat/templates/auditbeat.yml.j2
@@ -33,7 +33,7 @@ auditbeat.modules:
 {% if "oss" not in beat_pkg_suffix %}
 {% if version is version_compare('6.6', '>=') %}
 - module: system
-  metricsets:
+  datasets:
     - host
     - process
 {% if ansible_system == "Linux" %}


### PR DESCRIPTION
Since https://github.com/elastic/beats/issues/10018, the Auditbeat System module uses `datasets` instead of `metricsets` to configure its sub-modules. This reflects that change and fixes the [current CI failures](https://beats-ci.elastic.co/job/elastic+beats-tester+master/242/) for beats-tester on Windows.