### PR TITLE
Update registry path for 7.0

### DIFF
--- a/roles/test-beat/vars/filebeat.yml
+++ b/roles/test-beat/vars/filebeat.yml
@@ -1,4 +1,5 @@
 ---
 
-registry_file: registry
+# The default registry file path changed with 7.0.
+registry_file: '{{ "registry/filebeat/data.json" if version is version_compare("7.0", ">=") else "registry" }}'
 filebeat_logs_dir: '{{ ansible_user_dir }}/filebeat_logs'

--- a/run-settings-nightlies.yml
+++ b/run-settings-nightlies.yml
@@ -1,4 +1,4 @@
 # Beats "nightly" build artifacts.
 # Published by: https://beats-ci.elastic.co/job/elastic+beats+master+package/
 url_base: https://storage.googleapis.com/beats-ci-artifacts/snapshots
-version: 7.0.0-SNAPSHOT
+version: 8.0.0-SNAPSHOT

--- a/run-settings-released.yml
+++ b/run-settings-released.yml
@@ -1,3 +1,3 @@
 # Released artifacts.
 url_base: https://artifacts.elastic.co/downloads/beats
-version:  6.4.2
+version:  6.6.2

--- a/run-settings-snapshot.yml
+++ b/run-settings-snapshot.yml
@@ -1,4 +1,4 @@
 # Snapshot builds.
 # Published by: https://internal-ci.elastic.co/job/elastic+release-manager+master+unified-snapshot/
 url_base: https://snapshots.elastic.co/downloads/beats
-version: 7.0.0-SNAPSHOT
+version: 8.0.0-SNAPSHOT


### PR DESCRIPTION
The registry path changed in https://github.com/elastic/beats/pull/10504.