### PR TITLE
Update Winlogbeat assertions for 7.x

### DIFF
--- a/roles/test-beat/tasks/winlogbeat/assert.yml
+++ b/roles/test-beat/tasks/winlogbeat/assert.yml
@@ -10,7 +10,8 @@
 - debug:
     var: wlb_event
 
-- assert:
+- name: Assert Winlogbeat event contents (<7.0)
+  assert:
     that:
       - "'@timestamp' in wlb_event"
       - "'log_name' in wlb_event"
@@ -22,7 +23,8 @@
       - "'level' in wlb_event"
   when: "version | version_compare('7.0', '<')"
 
-- assert:
+- name: Assert Winlogbeat event contents (>=7.0)
+  assert:
     that:
       - "'@timestamp' in wlb_event"
       - "'channel' in wlb_event['winlog']"
@@ -32,7 +34,7 @@
       - "'record_id' in wlb_event['winlog']"
       - "'event_id' in wlb_event['winlog']"
       - "'level' in wlb_event['log']"
-  when: "version | version_compare('7.0', '<=')"
+  when: "version | version_compare('7.0', '>=')"
 
 - name: Assert Winlogbeat registry contents
   win_shell: 'cat -Encoding UTF8 {{ beat_registry_file }}'

--- a/roles/test-beat/tasks/winlogbeat/assert.yml
+++ b/roles/test-beat/tasks/winlogbeat/assert.yml
@@ -20,6 +20,19 @@
       - "'record_number' in wlb_event"
       - "'event_id' in wlb_event"
       - "'level' in wlb_event"
+  when: "version | version_compare('7.0', '<')"
+
+- assert:
+    that:
+      - "'@timestamp' in wlb_event"
+      - "'channel' in wlb_event['winlog']"
+      - "'provider_name' in wlb_event['winlog']"
+      - "'computer_name' in wlb_event['winlog']"
+      - "'api' in wlb_event['winlog']"
+      - "'record_id' in wlb_event['winlog']"
+      - "'event_id' in wlb_event['winlog']"
+      - "'level' in wlb_event['log']"
+  when: "version | version_compare('7.0', '<=')"
 
 - name: Assert Winlogbeat registry contents
   win_shell: 'cat -Encoding UTF8 {{ beat_registry_file }}'


### PR DESCRIPTION
Most core Winlogbeat fields were renamed for ECS so the assertions
needed to be updated.

Fixes #111