### PR TITLE
Keystore testing from package

### DIFF
--- a/roles/test-beat/tasks/auditbeat/pre-run.yml
+++ b/roles/test-beat/tasks/auditbeat/pre-run.yml
@@ -19,3 +19,19 @@
     path: '{{ ansible_user_dir }}/auditbeat_hello.txt'
     state: touch
   when: ansible_system != "Win32NT"
+
+# Verify that keystore works
+- name: Create a keystore
+  shell: auditbeat keystore add ES_PWD --stdin --force
+  args:
+    stdin: "hello"
+  register: auditbeat_keystore
+  when: ansible_system != "Win32NT"
+
+- name: Create a keystore (win)
+  win_shell: .\auditbeat keystore add ES_PWD --stdin --force --path.data "C:\\ProgramData\\auditbeat"
+  args:
+    chdir: '{{ beat_home_path }}'
+    stdin: "hello"
+  register: auditbeat_keystore_win
+  when: ansible_system == "Win32NT"

--- a/roles/test-beat/tasks/filebeat/pre-run.yml
+++ b/roles/test-beat/tasks/filebeat/pre-run.yml
@@ -60,3 +60,19 @@
       - "'system' in filebeat_modules_win.stdout"
     msg: filebeat modules list does not contain 'system'
   when: ansible_system == "Win32NT"
+
+# Verify that keystore works
+- name: Create a keystore
+  shell: filebeat keystore add ES_PWD --stdin --force
+  args:
+    stdin: "hello"
+  register: filebeat_keystore
+  when: ansible_system != "Win32NT"
+
+- name: Create a keystore (win)
+  win_shell: .\filebeat keystore add ES_PWD --stdin --force --path.data "C:\\ProgramData\\filebeat"
+  args:
+    chdir: '{{ beat_home_path }}'
+    stdin: "hello"
+  register: filebeat_keystore_win
+  when: ansible_system == "Win32NT"

--- a/roles/test-beat/tasks/heartbeat/pre-run.yml
+++ b/roles/test-beat/tasks/heartbeat/pre-run.yml
@@ -1,0 +1,15 @@
+# Verify that keystore works
+- name: Create a keystore
+  shell: heartbeat keystore add ES_PWD --stdin --force
+  args:
+    stdin: "hello"
+  register: heartbeat_keystore
+  when: ansible_system != "Win32NT"
+
+- name: Create a keystore (win)
+  win_shell: .\heartbeat keystore add ES_PWD --stdin --force --path.data "C:\\ProgramData\\heartbeat"
+  args:
+    chdir: '{{ beat_home_path }}'
+    stdin: "hello"
+  register: heartbeat_keystore_win
+  when: ansible_system == "Win32NT"

--- a/roles/test-beat/tasks/metricbeat/pre-run.yml
+++ b/roles/test-beat/tasks/metricbeat/pre-run.yml
@@ -24,3 +24,19 @@
       - "'system' in metricbeat_modules_win.stdout"
     msg: Metricbeat modules list does not contain 'system'
   when: ansible_system == "Win32NT"
+
+# Verify that keystore works
+- name: Create a keystore
+  shell: metricbeat keystore add ES_PWD --stdin --force
+  args:
+    stdin: "hello"
+  register: metricbeat_keystore
+  when: ansible_system != "Win32NT"
+
+- name: Create a keystore (win)
+  win_shell: .\metricbeat keystore add ES_PWD --stdin --force --path.data "C:\\ProgramData\\metricbeat"
+  args:
+    chdir: '{{ beat_home_path }}'
+    stdin: "hello"
+  register: metricbeat_keystore_win
+  when: ansible_system == "Win32NT"

--- a/roles/test-beat/tasks/packetbeat/pre-run.yml
+++ b/roles/test-beat/tasks/packetbeat/pre-run.yml
@@ -9,3 +9,19 @@
   set_fact:
     packetbeat_device: en0
   when: ansible_os_family == "Darwin"
+
+# Verify that keystore works
+- name: Create a keystore
+  shell: packetbeat keystore add ES_PWD --stdin --force
+  args:
+    stdin: "hello"
+  register: packetbeat_keystore
+  when: ansible_system != "Win32NT"
+
+- name: Create a keystore (win)
+  win_shell: .\packetbeat keystore add ES_PWD --stdin --force --path.data "C:\\ProgramData\\packetbeat"
+  args:
+    chdir: '{{ beat_home_path }}'
+    stdin: "hello"
+  register: packetbeat_keystore_win
+  when: ansible_system == "Win32NT"

--- a/roles/test-beat/tasks/winlogbeat/pre-run.yml
+++ b/roles/test-beat/tasks/winlogbeat/pre-run.yml
@@ -1,0 +1,7 @@
+- name: Create a keystore (win)
+  win_shell: .\winlogbeat keystore add ES_PWD --stdin --force --path.data "C:\\ProgramData\\winlogbeat"
+  args:
+    chdir: '{{ beat_home_path }}'
+    stdin: "hello"
+  register: winlogbeat_keystore_win
+  when: ansible_system == "Win32NT"

--- a/roles/test-beat/templates/auditbeat.yml.j2
+++ b/roles/test-beat/templates/auditbeat.yml.j2
@@ -29,6 +29,8 @@ auditbeat.modules:
 - module: file_integrity
   paths:
   - '{{ ansible_user_dir }}'
+  fields:
+    hello: ${ES_PWD}
 
 {% if "oss" not in beat_pkg_suffix %}
 {% if version is version_compare('6.6', '>=') %}

--- a/roles/test-beat/templates/auditbeat.yml.j2
+++ b/roles/test-beat/templates/auditbeat.yml.j2
@@ -29,8 +29,9 @@ auditbeat.modules:
 - module: file_integrity
   paths:
   - '{{ ansible_user_dir }}'
-  fields:
-    hello: ${ES_PWD}
+
+fields:
+  hello: ${ES_PWD}
 
 {% if "oss" not in beat_pkg_suffix %}
 {% if version is version_compare('6.6', '>=') %}

--- a/roles/test-beat/templates/filebeat.yml.j2
+++ b/roles/test-beat/templates/filebeat.yml.j2
@@ -6,6 +6,8 @@ filebeat.config.modules:
 filebeat.inputs:
 - paths:
   - '{{ filebeat_logs_dir }}/*.log'
+  fields:
+    hello: ${ES_PWD}
 
 output.file:
   path: '${path.logs}'

--- a/roles/test-beat/templates/filebeat.yml.j2
+++ b/roles/test-beat/templates/filebeat.yml.j2
@@ -6,8 +6,9 @@ filebeat.config.modules:
 filebeat.inputs:
 - paths:
   - '{{ filebeat_logs_dir }}/*.log'
-  fields:
-    hello: ${ES_PWD}
+
+fields:
+  hello: ${ES_PWD}
 
 output.file:
   path: '${path.logs}'

--- a/roles/test-beat/templates/heartbeat.yml.j2
+++ b/roles/test-beat/templates/heartbeat.yml.j2
@@ -4,6 +4,8 @@ heartbeat.monitors:
 - type: http
   schedule: '@every 1s'
   urls: ["http://localhost:12345"]
+  fields:
+    hello: ${ES_PWD}
 
 output.file:
   path: '${path.logs}'

--- a/roles/test-beat/templates/heartbeat.yml.j2
+++ b/roles/test-beat/templates/heartbeat.yml.j2
@@ -4,8 +4,9 @@ heartbeat.monitors:
 - type: http
   schedule: '@every 1s'
   urls: ["http://localhost:12345"]
-  fields:
-    hello: ${ES_PWD}
+
+fields:
+  hello: ${ES_PWD}
 
 output.file:
   path: '${path.logs}'

--- a/roles/test-beat/templates/metricbeat.yml.j2
+++ b/roles/test-beat/templates/metricbeat.yml.j2
@@ -9,6 +9,9 @@ output.file:
   path: '${path.logs}'
   filename: output.json
 
+fields:
+  hello: ${ES_PWD}
+
 logging:
   level: info
   json: true

--- a/roles/test-beat/templates/packetbeat.yml.j2
+++ b/roles/test-beat/templates/packetbeat.yml.j2
@@ -10,6 +10,9 @@ output.file:
   path: '${path.logs}'
   filename: output.json
 
+fields:
+  hello: ${ES_PWD}
+
 logging:
   level: info
   json: true

--- a/roles/test-beat/templates/winlogbeat.yml.j2
+++ b/roles/test-beat/templates/winlogbeat.yml.j2
@@ -5,6 +5,11 @@ output.file:
   path: '${path.logs}'
   filename: output.json
 
+fields:
+  hello: ${ES_PWD}
+
+
+
 logging:
   level: info
   json: true


### PR DESCRIPTION
Create a keys in the keystore and start the beat with a configuration
that use the key, if the key is missing the beat will refuse to start.
This assert that the path used by the packages is correct for the CLI
and the started service.

This is to stop regression like in https://github.com/elastic/beats/pull/11497


I have tested the changes with debian8 and windows box.