### PR TITLE
Exclude Windows from mounting tracefs/debugfs

### DIFF
--- a/roles/test-beat/tasks/auditbeat/pre-run.yml
+++ b/roles/test-beat/tasks/auditbeat/pre-run.yml
@@ -24,6 +24,7 @@
   stat:
     path: /sys/kernel/tracing
   register: tracefs
+  when: ansible_system == "Linux"
 
 # Use tracefs if it is configured in the kernel.
 - name: Mount tracefs for system/socket dataset
@@ -32,7 +33,9 @@
     src: nodev
     fstype: tracefs
     state: mounted
-  when: tracefs.stat.isdir is defined and tracefs.stat.isdir
+  when :
+    - ansible_system == "Linux"
+    - tracefs.stat.isdir is defined and tracefs.stat.isdir
 
 # Otherwise if tracefs is not configured then try to use debugfs.
 - name: Mount debugfs for system/socket dataset
@@ -41,4 +44,6 @@
     src: nodev
     fstype: debugfs
     state: mounted
-  when: tracefs.stat.isdir is not defined
+  when:
+    - ansible_system == "Linux"
+    - tracefs.stat.isdir is not defined


### PR DESCRIPTION
Add a conditional statement so that mounting debugfs/tracefs only happens on Linux.