### PR TITLE
Fix warnings for rpm command

### DIFF
--- a/roles/test-install/tasks/main.yml
+++ b/roles/test-install/tasks/main.yml
@@ -30,7 +30,7 @@
   when: ansible_os_family == "RedHat"
 
 - name: Install RPMs
-  command: rpm -i {{workdir}}/{{beat_pkg}}
+  zypper: name="{{ workdir }}/{{ beat_pkg }}" state=present
   when: ansible_os_family == "Suse"
 
 - name: Untar (darwin)


### PR DESCRIPTION
This fixes this warning:

```
 [WARNING]: Consider using the yum, dnf or zypper module rather than running 'rpm'.  If you need to use command because yum, dnf or zypper is insufficient you can add 'warn: false' to this command task or set 'command_warnings=False' in ansible.cfg to get rid of this message.
```