### PR TITLE
Add Elastic GPG key for zypper

### DIFF
--- a/roles/test-install/tasks/main.yml
+++ b/roles/test-install/tasks/main.yml
@@ -30,7 +30,9 @@
   when: ansible_os_family == "RedHat"
 
 - name: Install RPMs
-  zypper: name="{{ workdir }}/{{ beat_pkg }}" state=present
+  block:
+    - rpm_key: state=present key=https://packages.elastic.co/GPG-KEY-elasticsearch
+    - zypper: name="{{ workdir }}/{{ beat_pkg }}" state=present
   when: ansible_os_family == "Suse"
 
 - name: Untar (darwin)


### PR DESCRIPTION
This addresses the following issue:

```bash
vagrant@vagrant-sles-12-x64:~> sudo zypper install filebeat-7.4.0-x86_64.rpm
Loading repository data...
Reading installed packages...
Resolving package dependencies...

The following NEW package is going to be installed:
  filebeat

The following package is not supported by its vendor:
  filebeat

1 new package to install.
Overall download size: 22.8 MiB. Already cached: 0 B. After the operation, additional 74.5 MiB will be used.
Continue? [y/n/...? shows all options] (y):
Retrieving package filebeat-7.4.0-1.x86_64                                                                                          (1/1),  22.8 MiB ( 74.5 MiB unpacked)
filebeat-7.4.0-x86_64.rpm:
    Header V4 RSA/SHA512 Signature, key ID d88e42b4: NOKEY
    V4 RSA/SHA512 Signature, key ID d88e42b4: NOKEY

filebeat-7.4.0-1.x86_64 (Plain RPM files cache): Signature verification failed [4-Signatures public key is not available]
Abort, retry, ignore? [a/r/i] (a):
```