### PR TITLE
Don't test socket dataset on Ubuntu <= 12.04

### DIFF
--- a/roles/test-beat/templates/auditbeat.yml.j2
+++ b/roles/test-beat/templates/auditbeat.yml.j2
@@ -37,7 +37,10 @@ auditbeat.modules:
     - host
     - process
 {% if ansible_system == "Linux" %}
+{# Ubuntu 12.04 and earlier do not have certain IOCTL features back-ported to their kernel. #}
+{% if ansible_distribution != "Ubuntu" or ansible_distribution_version is not version_compare('12.04', '<=') %}
     - socket
+{% endif %}
     - user
   user.detect_password_changes: true
 {% endif %}


### PR DESCRIPTION
These systems lack PERF_EVENT_IOC_ID ioctl. See https://www.elastic.co/guide/en/beats/auditbeat/master/auditbeat-dataset-system-socket.html#_requirements.