### PR TITLE
Revert Ubuntu 20.04 support

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -164,14 +164,14 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     testvm.vm.provision "python", type: "shell", inline: ubuntu_provision_python()
   end
 
-  config.vm.define "tester-ubuntu2004-64" do |testvm|
-    testvm.vm.box = "ubuntu/focal64"
-
-    testvm.ssh.port = 2419
-    testvm.vm.network "forwarded_port", guest: 22, host: testvm.ssh.port, host_ip: "127.0.0.1"
-    testvm.vm.network "private_network", ip: "192.168.33.88"
-    testvm.vm.provision "python", type: "shell", inline: ubuntu_provision_python()
-  end
+#  config.vm.define "tester-ubuntu2004-64" do |testvm|
+#    testvm.vm.box = "ubuntu/focal64"
+#
+#    testvm.ssh.port = 2419
+#    testvm.vm.network "forwarded_port", guest: 22, host: testvm.ssh.port, host_ip: "127.0.0.1"
+#    testvm.vm.network "private_network", ip: "192.168.33.88"
+#    testvm.vm.provision "python", type: "shell", inline: ubuntu_provision_python()
+#  end
 
 end
 

--- a/hosts
+++ b/hosts
@@ -9,7 +9,7 @@ tester-ubuntu1204-32
 tester-ubuntu1404-64
 tester-ubuntu1604-64
 tester-ubuntu1804-64
-tester-ubuntu2004-64
+#tester-ubuntu2004-64
 
 [centos]
 tester-awslinux


### PR DESCRIPTION
I'm seeing this error on the Ubuntu 20.04 box.  I'd like to revert this until I can figure it out.

```08:14:57 Vagrant was unable to mount VirtualBox shared folders. This is usually
08:14:57 because the filesystem "vboxsf" is not available. This filesystem is
08:14:57 made available via the VirtualBox Guest Additions and kernel module.
08:14:57 Please verify that these guest additions are properly installed in the
08:14:57 guest. This is not a bug in Vagrant and is usually caused by a faulty
08:14:57 Vagrant box. For context, the command attempted was:
08:14:57 
08:14:57 mount -t vboxsf -o uid=1000,gid=1000 vagrant /vagrant
08:14:57 
08:14:57 The error output from the command was:
08:14:57 
08:14:57 : No such device```