### PR TITLE
Add support for Ubuntu 20.04

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -164,14 +164,15 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     testvm.vm.provision "python", type: "shell", inline: ubuntu_provision_python()
   end
 
-#  config.vm.define "tester-ubuntu2004-64" do |testvm|
-#    testvm.vm.box = "ubuntu/focal64"
-#
-#    testvm.ssh.port = 2419
-#    testvm.vm.network "forwarded_port", guest: 22, host: testvm.ssh.port, host_ip: "127.0.0.1"
-#    testvm.vm.network "private_network", ip: "192.168.33.88"
-#    testvm.vm.provision "python", type: "shell", inline: ubuntu_provision_python()
-#  end
+  config.vm.define "tester-ubuntu2004-64" do |testvm|
+    testvm.vm.box = "ubuntu/focal64"
+
+    testvm.ssh.port = 2419
+    testvm.vm.network "forwarded_port", guest: 22, host: testvm.ssh.port, host_ip: "127.0.0.1"
+    testvm.vm.network "private_network", ip: "192.168.33.88"
+    testvm.vm.provision "python", type: "shell", inline: ubuntu_provision_python()
+    testvm.vm.synced_folder ".", "/vagrant", disabled: true
+  end
 
 end
 
@@ -180,6 +181,6 @@ def ubuntu_provision_python()
   set -e
   export DEBIAN_FRONTEND=noninteractive
   apt-get update
-  apt-get install -y aptitude python-apt python-minimal python2.7
+  apt-get install -y aptitude python-apt python2.7
   SHELL
 end

--- a/hosts
+++ b/hosts
@@ -9,7 +9,7 @@ tester-ubuntu1204-32
 tester-ubuntu1404-64
 tester-ubuntu1604-64
 tester-ubuntu1804-64
-#tester-ubuntu2004-64
+tester-ubuntu2004-64
 
 [centos]
 tester-awslinux


### PR DESCRIPTION
- I disabled synced folders for Ubuntu 20.04
- `python-minimal` does not exist for Ubuntu `20.04`, but we're already installing `python2.7`.