### PR TITLE
Switch from RHEL 8 to CentOS 8

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -129,8 +129,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     testvm.vm.network "private_network", ip: "192.168.33.83"
   end
 
-  config.vm.define "tester-rhel8-64" do |testvm|
-    testvm.vm.box = "generic/rhel8"
+  config.vm.define "tester-centos8-64" do |testvm|
+    testvm.vm.box = "generic/centos8"
 
     testvm.ssh.port = 2415
     testvm.vm.network "forwarded_port", guest: 22, host: testvm.ssh.port, host_ip: "127.0.0.1"

--- a/hosts
+++ b/hosts
@@ -17,7 +17,7 @@ tester-awslinux2
 tester-centos6-32
 tester-centos6-64
 tester-centos7-64
-tester-rhel8-64
+tester-centos8-64
 
 [sles]
 tester-sles12-64


### PR DESCRIPTION
Originally when we added RHEL 8, CentOS 8 was not available.  Since CentOS 8 is out, I feel like we should switch for consistency.  We already have CentOS 6 and 7.