### PR TITLE
[jjbb]: elastic/beats-tester repo

### DIFF
--- a/.ci/jobs/beats-tester-mbp.yml
+++ b/.ci/jobs/beats-tester-mbp.yml
@@ -1,0 +1,43 @@
+---
+- job:
+    name: Beats/beats-tester-mbp
+    display-name: Pipeline for beats-tester
+    description: Jenkins pipeline for the beats-tester project.
+    view: Beats
+    project-type: multibranch
+    script-path: .ci/Jenkinsfile
+    scm:
+      - github:
+          branch-discovery: no-pr
+          discover-pr-forks-strategy: merge-current
+          discover-pr-forks-trust: permission
+          discover-pr-origin: merge-current          
+          discover-tags: true
+          notification-context: 'beats-ci'
+          repo: beats-tester
+          repo-owner: elastic
+          credentials-id: 2a9602aa-ab9f-4e52-baf3-b71ca88469c7-UserAndToken
+          ssh-checkout:
+            credentials: f6c7695a-671e-4f4f-a331-acdce44ff9ba
+          build-strategies:
+            - tags:
+                ignore-tags-older-than: -1
+                ignore-tags-newer-than: -1
+            - regular-branches: true
+            - change-request:
+                ignore-target-only-changes: false
+          clean:
+            after: true
+            before: true
+          prune: true
+          shallow-clone: true
+          depth: 4
+          do-not-fetch-tags: true
+          submodule:
+            disable: false
+            recursive: true
+            parent-credentials: true
+            timeout: 100
+          timeout: '15'
+          use-author: true
+          wipe-workspace: 'True'

--- a/.ci/jobs/defaults.yml
+++ b/.ci/jobs/defaults.yml
@@ -1,0 +1,20 @@
+  
+---
+
+##### GLOBAL METADATA
+
+- meta:
+    cluster: beats-ci
+
+##### JOB DEFAULTS
+
+- job:
+    logrotate:
+      numToKeep: 20
+    node: linux
+    concurrent: true
+    publishers:
+      - email:
+          recipients: infra-root+build@elastic.co
+    periodic-folder-trigger: 1w
+    prune-dead-branches: true


### PR DESCRIPTION
This is the very first approach to enable the CI pipeline in beats-ci.elastic.co using the JJBB.

Caused by https://github.com/elastic/beats-tester/issues/155