### PR TITLE
[ci]: MultiBranchPipeline

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -40,7 +40,7 @@ pipeline {
     }
     stage('Test Hosts'){
       matrix {
-        agent { label 'nested-virtualization' }
+        agent { label 'ubuntu-20 && nested-virtualization' }
         axes {
           axis {
             name 'GROUPS'

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -9,6 +9,7 @@ pipeline {
     PIPELINE_LOG_LEVEL = 'INFO'
     URL_BASE = "${params.URL_BASE}"
     VERSION = "${params.VERSION}"
+    HOME = "${WORKSPACE}"
   }
   options {
     timeout(time: 2, unit: 'HOURS')
@@ -53,6 +54,7 @@ pipeline {
       post {
         always {
           dir("${BASE_DIR}"){
+            archiveArtifacts(allowEmptyArchive: true, artifacts: '**/logs/**')
             sh(label: 'make clean', script: 'make clean')
           }          
         }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -1,0 +1,75 @@
+#!/usr/bin/env groovy
+
+@Library('apm@current') _
+
+pipeline {
+  agent { label 'metal' }
+  environment {
+    BASE_DIR = 'src'
+    PIPELINE_LOG_LEVEL = 'INFO'
+    URL_BASE = "${params.URL_BASE}"
+    VERSION = "${params.VERSION}"
+  }
+  options {
+    timeout(time: 2, unit: 'HOURS')
+    buildDiscarder(logRotator(numToKeepStr: '20', artifactNumToKeepStr: '20', daysToKeepStr: '30'))
+    timestamps()
+    ansiColor('xterm')
+    disableResume()
+    durabilityHint('PERFORMANCE_OPTIMIZED')
+    quietPeriod(10)
+    rateLimitBuilds(throttle: [count: 60, durationName: 'hour', userBoost: true])
+  }
+  triggers {
+    issueCommentTrigger('(?i).*(?:jenkins\\W+)?run\\W+(?:the\\W+)?tests(?:\\W+please)?.*')
+  }
+  parameters {
+    string(name: 'URL_BASE', defaultValue: 'https://storage.googleapis.com/beats-ci-artifacts/snapshots', description: 'The location where the packages should be downloaded from')
+    string(name: 'VERSION', defaultValue: '8.0.0-SNAPSHOT', description: 'The package version to test (modify the job configuration to add a new version)')
+  }
+  stages {
+    stage('Checkout') {
+      options { skipDefaultCheckout() }
+      steps {
+        pipelineManager([ cancelPreviousRunningBuilds: [ when: 'PR' ] ])
+        deleteDir()
+        gitCheckout(basedir: "${BASE_DIR}", githubNotifyFirstTimeContributor: true)
+        stash allowEmpty: true, name: 'source', useDefaultExcludes: false
+      }
+    }
+    stage('Test'){
+      options { skipDefaultCheckout() }
+      steps {
+        deleteDir()
+        unstash 'source'
+        dir("${BASE_DIR}"){
+          sh(label: 'make ci', 
+             script: '''#!/bin/bash
+              printf 'VERSION=%s\n'"$VERSION"
+              cat << EOF > run-settings-jenkins.yml
+              url_base: ${URL_BASE}
+              version: ${VERSION}
+              EOF
+              cleanup() {
+                vagrant destroy -f
+              }
+              trap cleanup EXIT
+              RUN_SETTINGS=jenkins make ci''')
+        }
+      }
+      post {
+        always {
+          dir("${BASE_DIR}"){
+            sh(label: 'make clean', script: 'make clean')
+          }          
+        }
+      }
+    }
+  }
+  post {
+    cleanup {
+      notifyBuildResult(prComment: true)
+      deleteDir()
+    }
+  }
+}

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -40,7 +40,7 @@ pipeline {
     }
     stage('Test Hosts'){
       matrix {
-        agent { label 'metal || apple' }
+        agent { label 'linux && immutable' }
         axes {
           axis {
             name 'GROUPS'

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -40,15 +40,11 @@ pipeline {
     }
     stage('Test Hosts'){
       matrix {
-        // TODO: when the infra is ready with the 'nested-virtualization' then we can use that label
-        // agent { label 'nested-virtualization' }
-        agent { label 'metal' }
+        agent { label 'nested-virtualization' }
         axes {
           axis {
             name 'GROUPS'
-            // TODO: when the infra is ready with the 'nested-virtualization' then we can split in stages
-            // values 'centos', 'debian', 'sles', 'windows'
-            values 'centos debian sles windows'
+            values 'centos', 'debian', 'sles', 'windows'
           }
         }
         stages {

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -40,7 +40,7 @@ pipeline {
     }
     stage('Test Hosts'){
       matrix {
-        agent { label 'metal' }
+        agent { label 'metal || apple' }
         axes {
           axis {
             name 'GROUPS'

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -64,7 +64,8 @@ pipeline {
             post {
               always {
                 dir("${BASE_DIR}"){
-                  archiveArtifacts(allowEmptyArchive: true, artifacts: '**/logs/**')
+                  junit(allowEmptyResults: true, keepLongStdio: true, testResults: "logs/*.xml")
+                  archiveArtifacts(allowEmptyArchive: true, artifacts: 'logs/**')
                   sh(label: 'make clean', script: 'make clean')
                 }
               }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -12,7 +12,7 @@ pipeline {
     HOME = "${WORKSPACE}"
   }
   options {
-    timeout(time: 2, unit: 'HOURS')
+    timeout(time: 4, unit: 'HOURS')
     buildDiscarder(logRotator(numToKeepStr: '20', artifactNumToKeepStr: '20', daysToKeepStr: '30'))
     timestamps()
     ansiColor('xterm')
@@ -40,11 +40,15 @@ pipeline {
     }
     stage('Test Hosts'){
       matrix {
-        agent { label 'linux && immutable' }
+        // TODO: when the infra is ready with the 'nested-virtualization' then we can use that label
+        // agent { label 'nested-virtualization' }
+        agent { label 'metal' }
         axes {
           axis {
             name 'GROUPS'
-            values 'centos', 'debian', 'sles', 'windows'
+            // TODO: when the infra is ready with the 'nested-virtualization' then we can split in stages
+            // values 'centos', 'debian', 'sles', 'windows'
+            values 'centos debian sles windows'
           }
         }
         stages {

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -44,17 +44,10 @@ pipeline {
         unstash 'source'
         dir("${BASE_DIR}"){
           sh(label: 'make ci', 
-             script: '''#!/bin/bash
-              printf 'VERSION=%s\n'"$VERSION"
-              cat << EOF > run-settings-jenkins.yml
-              url_base: ${URL_BASE}
-              version: ${VERSION}
-              EOF
-              cleanup() {
-                vagrant destroy -f
-              }
-              trap cleanup EXIT
-              RUN_SETTINGS=jenkins make ci''')
+             script: """#!/bin/bash
+              echo "url_base: ${URL_BASE}" > run-settings-jenkins.yml
+              echo "version: ${VERSION}" >> run-settings-jenkins.yml
+              RUN_SETTINGS=jenkins make ci""")
         }
       }
       post {

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -40,11 +40,15 @@ pipeline {
     }
     stage('Test Hosts'){
       matrix {
-        agent { label 'ubuntu-20 && nested-virtualization' }
+        // TODO: when the infra is ready with the 'nested-virtualization' then we can use that label
+        // agent { label 'nested-virtualization' }
+        agent { label 'metal' }
         axes {
           axis {
             name 'GROUPS'
-            values 'centos', 'debian', 'sles', 'windows'
+            // TODO: when the infra is ready with the 'nested-virtualization' then we can split in stages
+            // values 'centos', 'debian', 'sles', 'windows'
+            values 'centos debian sles windows'
           }
         }
         stages {

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -3,7 +3,7 @@
 @Library('apm@current') _
 
 pipeline {
-  agent { label 'metal' }
+  agent { label 'linux && immutable' }
   environment {
     BASE_DIR = 'src'
     PIPELINE_LOG_LEVEL = 'INFO'
@@ -38,25 +38,41 @@ pipeline {
         stash allowEmpty: true, name: 'source', useDefaultExcludes: false
       }
     }
-    stage('Test'){
-      options { skipDefaultCheckout() }
-      steps {
-        deleteDir()
-        unstash 'source'
-        dir("${BASE_DIR}"){
-          sh(label: 'make ci', 
-             script: """#!/bin/bash
-              echo "url_base: ${URL_BASE}" > run-settings-jenkins.yml
-              echo "version: ${VERSION}" >> run-settings-jenkins.yml
-              RUN_SETTINGS=jenkins make ci""")
+    stage('Test Hosts'){
+      matrix {
+        agent { label 'metal' }
+        axes {
+          axis {
+            name 'GROUPS'
+            values 'centos', 'debian', 'sles', 'windows'
+          }
         }
-      }
-      post {
-        always {
-          dir("${BASE_DIR}"){
-            archiveArtifacts(allowEmptyArchive: true, artifacts: '**/logs/**')
-            sh(label: 'make clean', script: 'make clean')
-          }          
+        stages {
+          stage('Test'){
+            options { skipDefaultCheckout() }
+            steps {
+              deleteDir()
+              unstash 'source'
+              dir("${BASE_DIR}"){
+                sh(label: 'make batch',
+                  script: """#!/bin/bash
+                    echo "url_base: ${URL_BASE}" > run-settings-jenkins.yml
+                    echo "version: ${VERSION}" >> run-settings-jenkins.yml
+                    RUN_SETTINGS=jenkins make batch""")
+              }
+            }
+            post {
+              always {
+                dir("${BASE_DIR}"){
+                  archiveArtifacts(allowEmptyArchive: true, artifacts: '**/logs/**')
+                  sh(label: 'make clean', script: 'make clean')
+                }
+              }
+              cleanup {
+                deleteDir()
+              }
+            }
+          }
         }
       }
     }
@@ -64,7 +80,6 @@ pipeline {
   post {
     cleanup {
       notifyBuildResult(prComment: true)
-      deleteDir()
     }
   }
 }

--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,8 @@ ci: batch
 # Run Ansible from the virtualenv.
 ansible-playbook-run-%: ve
 	OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES \
+	JUNIT_TASK_CLASS=yes \
+	JUNIT_OUTPUT_DIR=logs \
 	ve/bin/ansible-playbook \
 	${ANSIBLE_VERBOSE} \
 	-i hosts \

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ batch:
 run-group: HOSTS=$(shell ansible ${GROUP} -i hosts --list-hosts | tail -n +2)
 # For each ansible group, start the vm, check the vm's status, configure
 # ssh, run the ansible playbook, and finally destroy the vm.
-run-group:
+run-group: ve
 	vagrant up ${HOSTS}
 	vagrant status ${HOSTS}
 	vagrant ssh-config ${HOSTS} >ssh_config

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,0 +1,2 @@
+[defaults]
+callback_whitelist = junit

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 ansible==2.8.8
+junit-xml==1.8
 pywinrm>=0.2.2
 markupsafe

--- a/roles/test-install/tasks/main.yml
+++ b/roles/test-install/tasks/main.yml
@@ -2,18 +2,26 @@
 
 - name: 'Remove {{ beat_pkg_name }} rpm if it exists'
   yum: name={{ beat_pkg_name }} state=absent lock_timeout=900
+  retries: 3
+  delay: 10
   when: ansible_os_family == "RedHat"
 
 - name: 'Remove {{ beat_pkg_name }} rpm if it exists'
   zypper: name={{ beat_pkg_name }} state=absent
+  retries: 3
+  delay: 10
   when: ansible_os_family == "Suse"
 
 - name: 'Remove {{ beat_pkg_name }} deb if it exists'
   apt: name={{ beat_pkg_name }} state=absent
+  retries: 3
+  delay: 10
   when: ansible_os_family == "Debian"
 
 - name: Install Debs (apt)
   apt: deb={{workdir}}/{{beat_pkg}} state=present
+  retries: 3
+  delay: 10
   when:
     - ansible_os_family == "Debian"
     - ansible_distribution_major_version != "6"
@@ -21,12 +29,16 @@
 # XXX: Workaround for https://github.com/ansible/ansible/issues/31471.
 - name: Install Debs (dpkg)
   command: dpkg -i {{workdir}}/{{beat_pkg}}
+  retries: 3
+  delay: 10
   when:
     - ansible_os_family == "Debian"
     - ansible_distribution_major_version == "6"
 
 - name: Install RPMs
   yum: name={{workdir}}/{{beat_pkg}} state=present lock_timeout=900
+  retries: 3
+  delay: 10
   when: ansible_os_family == "RedHat"
 
 - name: Install RPMs

--- a/roles/test-uninstall/tasks/main.yml
+++ b/roles/test-uninstall/tasks/main.yml
@@ -10,14 +10,20 @@
 
 - name: 'Uninstall {{ beat_pkg_name }} deb'
   apt: name={{ beat_pkg_name }} state=absent purge=true
+  retries: 3
+  delay: 10
   when: ansible_os_family == "Debian"
 
 - name: 'Uninstall {{ beat_pkg_name }} rpm'
   yum: name={{ beat_pkg_name }} state=absent lock_timeout=900
+  retries: 3
+  delay: 10
   when: ansible_os_family == "RedHat"
 
 - name: 'Uninstall {{ beat_pkg_name }} rpm'
   zypper: name={{ beat_pkg_name }} state=absent
+  retries: 3
+  delay: 10
   when: ansible_os_family == "Suse"
 
 - name: Delete directory (darwin)


### PR DESCRIPTION
## What

- Enable CI Pipeline for any changes related to Pull Requests, branches or tags in this repo
- Supports JUnit reporting (see [ansible-junit-callback](https://docs.ansible.com/ansible/latest/plugins/callback/junit.html)) 
- Add retries/sleeps when running ansible tasks to install/uninstall packages since the metadata repos might be not accessible as I've already seen in a couple of test runs.

## Why

It will help us to test things in the CI (such as: upgrade the ansible version)

## UI

![image](https://user-images.githubusercontent.com/2871786/86129130-1ec3b280-bada-11ea-9f11-fe255e3667de.png)


## Issues

Depends on https://github.com/elastic/beats-tester/pull/156

## TODO

- parallel stages to avoid the over 2 hours run build -> for instance [this](https://beats-ci.elastic.co/blue/organizations/jenkins/Beats%2Fbeats-tester-mbp%2FPR-157/detail/PR-157/3/pipeline)

The parallel setup is not the one defined in the Makefile but in the CI Pipeline, therefore if required to set a new group of platforms to run in the CI then it will be required to be configured in the CI Pipeline.
