### PR TITLE
[CI] force Python to use UTF-8 by default

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -7,7 +7,8 @@ pipeline {
   environment {
     BASE_DIR = 'src'
     PIPELINE_LOG_LEVEL = 'INFO'
-    URL_BASE = "${params.URL_BASE}"
+    APM_URL_BASE = "${params.APM_URL_BASE}"
+    BEATS_URL_BASE = "${params.BEATS_URL_BASE}"
     VERSION = "${params.VERSION}"
     HOME = "${WORKSPACE}"
     LANG = "C.UTF-8"

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -10,6 +10,9 @@ pipeline {
     URL_BASE = "${params.URL_BASE}"
     VERSION = "${params.VERSION}"
     HOME = "${WORKSPACE}"
+    LANG = "C.UTF-8"
+    LC_ALL = "C.UTF-8"
+    PYTHONUTF8 = "1"
   }
   options {
     timeout(time: 4, unit: 'HOURS')


### PR DESCRIPTION
See if the below stacktrace error gets resolved

```
11:23:22  UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 4: ordinal not in range(128)
11:23:22  Makefile:17: recipe for target 've/bin/activate' failed
11:23:22  make[1]: *** [ve/bin/activate] Error 1
11:23:22  make[1]: Leaving directory '/var/lib/jenkins/workspace/Beats_beats-tester-mbp_master/src'
11:23:22  Makefile:29: recipe for target 'batch' failed
11:23:22  make: *** [batch] Error 1
```