### PR TITLE
[CI] enable slack notifications for build failures in branches/tags

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -140,5 +140,8 @@ pipeline {
     cleanup {
       notifyBuildResult(prComment: true)
     }
+    unsuccessful {
+      slackSend channel: '#observablt-robots', color: 'danger', message: 'Build Failed: ${env.JOB_NAME} ${env.BUILD_NUMBER}', tokenCredentialId: 'jenkins-slack-integration-token'
+    }
   }
 }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -141,7 +141,7 @@ pipeline {
       notifyBuildResult(prComment: true)
     }
     unsuccessful {
-      slackSend channel: '#observablt-robots', color: 'danger', message: 'Build Failed: ${env.JOB_NAME} ${env.BUILD_NUMBER}', tokenCredentialId: 'jenkins-slack-integration-token'
+      slackSend channel: '#observablt-robots', color: 'danger', message: "Build Failed: ${env.JOB_NAME} ${env.BUILD_NUMBER}", tokenCredentialId: 'jenkins-slack-integration-token'
     }
   }
 }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -141,7 +141,11 @@ pipeline {
       notifyBuildResult(prComment: true)
     }
     unsuccessful {
-      slackSend channel: '#observablt-robots', color: 'danger', message: "Build Failed: ${env.JOB_NAME} ${env.BUILD_NUMBER}", tokenCredentialId: 'jenkins-slack-integration-token'
+      whenFalse(isPR()) {
+        slackSend(channel: '#observablt-robots', color: 'danger',
+                  message: "Build Failed: ${env.JOB_NAME} ${env.BUILD_NUMBER} (<${env.RUN_DISPLAY_URL}|Open>).",
+                  tokenCredentialId: 'jenkins-slack-integration-token')
+      }
     }
   }
 }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -141,7 +141,7 @@ pipeline {
       notifyBuildResult(prComment: true)
     }
     unsuccessful {
-      whenTrue(isPR()) {
+      whenFalse(isPR()) {
         slackSend(channel: '#observablt-robots', color: 'danger',
                   message: "Build Failed: ${env.JOB_NAME} ${env.BUILD_NUMBER} (<${env.RUN_DISPLAY_URL}|Open>).",
                   tokenCredentialId: 'jenkins-slack-integration-token')

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -141,7 +141,7 @@ pipeline {
       notifyBuildResult(prComment: true)
     }
     unsuccessful {
-      whenFalse(isPR()) {
+      whenTrue(isPR()) {
         slackSend(channel: '#observablt-robots', color: 'danger',
                   message: "Build Failed: ${env.JOB_NAME} ${env.BUILD_NUMBER} (<${env.RUN_DISPLAY_URL}|Open>).",
                   tokenCredentialId: 'jenkins-slack-integration-token')


### PR DESCRIPTION
This a follow up for https://github.com/elastic/beats-tester/pull/162

## Tests

![image](https://user-images.githubusercontent.com/2871786/90124329-81a69b80-dd60-11ea-8b8b-83396a456c8d.png)
