### PR TITLE
Update registry path for 7.9

### DIFF
--- a/roles/test-beat/vars/filebeat.yml
+++ b/roles/test-beat/vars/filebeat.yml
@@ -1,5 +1,5 @@
 ---
 
-# The default registry file path changed with 7.0.
-registry_file: '{{ "registry/filebeat/data.json" if version is version_compare("7.0", ">=") else "registry" }}'
+# The default registry file path changed with 7.0 and 7.9
+registry_file: '{{ "registry/filebeat/log.json" if version is version_compare("7.9", ">=") elif version is version_compare("7.0", ">=") "registry/filebeat/data.json" else "registry" }}'
 filebeat_logs_dir: '{{ ansible_user_dir }}/filebeat_logs'

--- a/roles/test-beat/vars/filebeat.yml
+++ b/roles/test-beat/vars/filebeat.yml
@@ -1,5 +1,5 @@
 ---
 
 # The default registry file path changed with 7.0 and 7.9
-registry_file: '{{ "registry/filebeat/log.json" if version is version_compare("7.9", ">=") elif version is version_compare("7.0", ">=") "registry/filebeat/data.json" else "registry" }}'
+registry_file: "{% if version is version_compare('7.9', '>=') %}registry/filebeat/log.json{% elif version is version_compare('7.0', '>=') %}registry/filebeat/data.json{% else %}registry{% endif %}"
 filebeat_logs_dir: '{{ ansible_user_dir }}/filebeat_logs'


### PR DESCRIPTION
The registry path changed in https://github.com/elastic/beats/pull/19633


Otherwise:

```
Error
file not found: /var/lib/filebeat/registry/filebeat/data.json
Stacktrace
{
"changed": false, 
"msg": "file not found: /var/lib/filebeat/registry/filebeat/data.json"
}
```

### Test locally

```
$ cat run-settings-jenkins.yml 
# Beats "jenkins" build artifacts.
# Published by: https://beats-ci.elastic.co/job/elastic+beats+master+package/
beats_url_base: https://snapshots.elastic.co/8.0.0-7025cc53/downloads/beats
apm_url_base: https://snapshots.elastic.co/8.0.0-7025cc53/downloads/apm-server
version: 8.0.0-SNAPSHOT
$ RUN_SETTINGS=jenkins GROUPS=sles make batch
...
PLAY RECAP *************************************************************************************************************************************************************************************************
tester-sles12-64           : ok=382  changed=176  unreachable=0    failed=0    skipped=222  rescued=0    ignored=0   

vagrant destroy -f     tester-sles12-64
==> tester-sles12-64: Forcing shutdown of VM...
==> tester-sles12-64: Destroying VM and associated drives...