### PR TITLE
The box 'ubuntu/precise32' could not be found

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -27,13 +27,12 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   end
 
   config.vm.define "tester-ubuntu1204-32" do |testvm|
-    testvm.vm.box = "ubuntu/precise32"
+    testvm.vm.box = "hashicorp/precise32"
 
     testvm.ssh.port = 2403
     testvm.vm.network "forwarded_port", guest: 22, host: testvm.ssh.port, host_ip: "127.0.0.1"
     testvm.vm.network "private_network", ip: "192.168.33.72"
   end
-
 
   config.vm.define "tester-debian8-64" do |testvm|
     config.vm.box = "debian/jessie64"


### PR DESCRIPTION
## What

```
[2020-09-02T16:54:12.096Z] The box 'ubuntu/precise32' could not be found or
[2020-09-02T16:54:12.096Z] could not be accessed in the remote catalog. If this is a private
[2020-09-02T16:54:12.096Z] box on HashiCorp's Vagrant Cloud, please verify you're logged in via
[2020-09-02T16:54:12.096Z] `vagrant login`. Also, please double-check the name. The expanded
[2020-09-02T16:54:12.096Z] URL and error message are shown below:
[2020-09-02T16:54:12.096Z] 
[2020-09-02T16:54:12.096Z] URL: ["https://vagrantcloud.com/ubuntu/precise32"]
[2020-09-02T16:54:12.096Z] Error: The requested URL returned error: 404 Not Found
```

![image](https://user-images.githubusercontent.com/2871786/92090260-1f711180-edc7-11ea-9d59-2d743f47880d.png)


## Tests

Build successfully downloaded the vagrant box

```
==> tester-ubuntu1204-32: Successfully added box 'hashicorp/precise32' (v1.0.0) for 'virtualbox'!
[2020-09-03T08:49:26.780Z] ==> tester-ubuntu1204-32: Importing base box 'hashicorp/precise32'...
```