### PR TITLE
Bump ansible version (2.9.13)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-ansible==2.8.8
+ansible==2.9.13
 junit-xml==1.8
 pywinrm>=0.2.2
 markupsafe

--- a/roles/common/tasks/download.yml
+++ b/roles/common/tasks/download.yml
@@ -1,24 +1,18 @@
 
-- name: Download package sha512
-  get_url: url={{beat_url}}.sha512 dest={{workdir}} validate_certs=no
-  when: not ansible_os_family == "Windows"
+- name: Download package with checksum (linux/darwin)
+  get_url:
+    url: "{{beat_url}}"
+    dest: "{{workdir}}"
+    validate_certs: no
+    timeout: 60
+    checksum: "sha512:{{beat_url}}.sha512"
+  when: ansible_os_family != "Windows"
 
-- name: Download package sha512 (windows)
-  win_get_url: url={{beat_url}}.sha512 dest={{workdir}}/{{beat_pkg}}.sha512 validate_certs=no
+- name: Download package with checksum (windows)
+  get_url:
+    url: "{{beat_url}}"
+    dest: "{{workdir}}"
+    validate_certs: no
+    timeout: 60
+    checksum: "sha512:{{beat_url}}.sha512"
   when: ansible_os_family == "Windows"
-
-- name: Download package
-  get_url: url={{beat_url}} dest={{workdir}} validate_certs=no
-  when: not ansible_os_family == "Windows"
-
-- name: Download package (windows)
-  win_get_url: url={{beat_url}} dest={{workdir}}/{{beat_pkg}} validate_certs=no force=no
-  when: ansible_os_family == "Windows"
-
-- name: Check file (linux)
-  shell: chdir={{workdir}} sha512sum -c {{beat_pkg}}.sha512
-  when: ansible_os_family in ["RedHat", "Debian", "Suse"]
-
-- name: Check file (darwin)
-  shell: chdir={{workdir}} shasum -a 512 -c {{beat_pkg}}.sha512
-  when: ansible_os_family == "Darwin"

--- a/roles/test-beat/tasks/main.yml
+++ b/roles/test-beat/tasks/main.yml
@@ -16,9 +16,6 @@
   include_vars: '{{ item }}'
   with_first_found:
   - files:
-    - 'vars/{{ ansible_distribution_id | lower }}.yml'
-    - 'vars/{{ ansible_distribution | lower }}.yml'
-    - 'vars/{{ ansible_os_family | lower }}.yml'
     - 'vars/{{ ansible_system | lower }}.yml'
     - default.yml
 

--- a/roles/test-linux-binary/tasks/main.yml
+++ b/roles/test-linux-binary/tasks/main.yml
@@ -9,14 +9,10 @@
 - name: Ensure empty output directory
   file: path={{workdir}}/output state=absent
 
-- name: Download package sha512
-  get_url: url={{beat_url}}.sha512 dest={{workdir}} validate_certs=no
-
-- name: Download package
-  get_url: url={{beat_url}} dest={{workdir}} validate_certs=no
-
-- name: Check file (linux)
-  shell: chdir={{workdir}} sha512sum -c {{beat_pkg}}.sha512
+- name: Download package and checksum
+  include_role:
+    name: common
+    tasks_from: download
 
 - name: Create install directory
   file: path={{installdir}} state=directory


### PR DESCRIPTION
### What

Porting reference: https://docs.ansible.com/ansible/latest/porting_guides/porting_guide_2.9.html\#porting-custom-scripts

This will solve the issues regarding:

* TASK [test-beat : apm-server - include OS vars] - No file was found when using first_found.
* TASK [test-beat : Set config/output/log file vars] - The error was: 'installdir' is undefined

### Issues

Closes 	https://github.com/elastic/beats-tester/issues/144