### PR TITLE
Use cached folder with the vagrant boxes

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -56,8 +56,8 @@ pipeline {
           stage('Test'){
             options { skipDefaultCheckout() }
             environment {
-              VAGRANT_HOME = "${env.HOME}/.vagrant.d"
-              HOME = "${env.WORKSPACE}"
+              VAGRANT_HOME = "${env.JENKINS_HOME}/.vagrant.d"
+              HOME = "${env.WORKSPACE}" // HOME is not set in some workers
             }
             steps {
               deleteDir()

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -10,9 +10,11 @@ pipeline {
     APM_URL_BASE = "${params.APM_URL_BASE}"
     BEATS_URL_BASE = "${params.BEATS_URL_BASE}"
     VERSION = "${params.VERSION}"
+    HOME = "${env.WORKSPACE}" // HOME is not set in some workers
     LANG = "C.UTF-8"
     LC_ALL = "C.UTF-8"
     PYTHONUTF8 = "1"
+    VAGRANT_HOME = "${env.JENKINS_HOME}/.vagrant.d"
   }
   options {
     timeout(time: 4, unit: 'HOURS')
@@ -55,18 +57,9 @@ pipeline {
         stages {
           stage('Test'){
             options { skipDefaultCheckout() }
-            environment {
-              VAGRANT_HOME = "${env.JENKINS_HOME}/.vagrant.d"
-              HOME = "${env.WORKSPACE}" // HOME is not set in some workers
-            }
             steps {
               deleteDir()
               unstash 'source'
-              sh(label: 'Debug vagrant context',
-                script: """#!/bin/bash
-                  env | sort
-                  find ${VAGRANT_HOME} -type f -ls || true
-                """)
               dir("${BASE_DIR}"){
                 sh(label: 'make batch',
                   script: """#!/bin/bash

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -57,6 +57,7 @@ pipeline {
             options { skipDefaultCheckout() }
             environment {
               VAGRANT_HOME = "${env.HOME}/.vagrant.d"
+              HOME = "${env.WORKSPACE}"
             }
             steps {
               deleteDir()

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -62,6 +62,11 @@ pipeline {
             steps {
               deleteDir()
               unstash 'source'
+              sh(label: 'Debug vagrant context',
+                script: """#!/bin/bash
+                  env | sort
+                  find ${VAGRANT_HOME} -type f -ls || true
+                """)
               dir("${BASE_DIR}"){
                 sh(label: 'make batch',
                   script: """#!/bin/bash

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -10,7 +10,6 @@ pipeline {
     APM_URL_BASE = "${params.APM_URL_BASE}"
     BEATS_URL_BASE = "${params.BEATS_URL_BASE}"
     VERSION = "${params.VERSION}"
-    HOME = "${WORKSPACE}"
     LANG = "C.UTF-8"
     LC_ALL = "C.UTF-8"
     PYTHONUTF8 = "1"
@@ -56,6 +55,10 @@ pipeline {
         stages {
           stage('Test'){
             options { skipDefaultCheckout() }
+            environment {
+              VAGRANT_HOME = "${env.HOME}/.vagrant.d"
+              HOME = "${env.WORKSPACE}"
+            }
             steps {
               deleteDir()
               unstash 'source'

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -57,7 +57,6 @@ pipeline {
             options { skipDefaultCheckout() }
             environment {
               VAGRANT_HOME = "${env.HOME}/.vagrant.d"
-              HOME = "${env.WORKSPACE}"
             }
             steps {
               deleteDir()


### PR DESCRIPTION
## What

Change the location where the vagrant boxes are cached to the default HOME/.vagrant.d.

## Why

This will speed up the builds since the boxes will be already cached.


```
[2020-09-04T10:48:28.004Z] 
...
Download redirected to host: vagrantcloud-files-production.s3.amazonaws.com
....
[2020-09-04T10:56:12.985Z] ==> tester-awslinux2: Successfully added box 'gbailey/amzn2' (v20200825.0.0) for 'virtualbox'!
...
```