### PR TITLE
[DOCS] Update OS matrix support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,4 +71,15 @@ clean:
 	-vagrant destroy -f
 	-rm -r .vagrant
 
+# Generate markdown compatibility matrix
+markdown-matrix:
+	@ansible -i hosts --list-hosts all | \
+		sort | \
+		grep -v tester-es | \
+		grep -v '^#' | \
+		grep tester | \
+		sed 's#tester-##g' | \
+		tr -d " " | \
+		sed 's#\(.*\)#\1 | :white_check_mark:#g'
+
 .PHONY: batch clean run run-elastic run-group run-oss setup ve

--- a/README.md
+++ b/README.md
@@ -23,8 +23,6 @@ ubuntu1604-64 | :white_check_mark:
 ubuntu1804-64 | :white_check_mark:
 ubuntu2004-64 | :white_check_mark:
 win12-64 | :white_check_mark:
-win16-64 | :white_check_mark:
-win19-64 | :white_check_mark:
 
 ## Execute
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,29 @@
 Vagrant + Ansible setup for testing the OS packages and basic e2e tests for all
 the [Beats](https://www.elastic.co/products/beats).
 
+## OS matrix
+
+  OS | Support
+---- | -------
+awslinux | :white_check_mark:
+awslinux2 | :white_check_mark:
+centos6-32 | :white_check_mark:
+centos6-64 | :white_check_mark:
+centos7-64 | :white_check_mark:
+centos8-64 | :white_check_mark:
+debian10-64 | :white_check_mark:
+debian8-64 | :white_check_mark:
+debian9-64 | :white_check_mark:
+sles12-64 | :white_check_mark:
+ubuntu1204-32 | :white_check_mark:
+ubuntu1404-64 | :white_check_mark:
+ubuntu1604-64 | :white_check_mark:
+ubuntu1804-64 | :white_check_mark:
+ubuntu2004-64 | :white_check_mark:
+win12-64 | :white_check_mark:
+win16-64 | :white_check_mark:
+win19-64 | :white_check_mark:
+
 ## Execute
 
 First, you need to bring the machines up:


### PR DESCRIPTION
This is a cherry-pick from the open PR: https://github.com/elastic/beats-tester/pull/158

## What

Generate the matrix table of support with some automation

`make markdown-matrix` will return the table of supported OS versions that are tested when running the beats-tester

## Screenshots


See https://github.com/elastic/beats-tester/pull/178/files?short_path=04c6e90#diff-04c6e90faac2675aa89e2176d2eec7d8




