### PR TITLE
Fix CentOS 6 EOL package URL

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -14,6 +14,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     testvm.ssh.port = 2401
     testvm.vm.network "forwarded_port", guest: 22, host: testvm.ssh.port, host_ip: "127.0.0.1"
     testvm.vm.network "private_network", ip: "192.168.33.70"
+    ## EOL for CentOS 6 so using the package location in http://vault.centos.org
+    testvm.vm.provision "shell", inline: "sed -ibck  's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-Base.repo"
     testvm.vm.provision "shell", inline: "yum install -y libselinux-python"
     testvm.vm.provider "virtualbox" do |v|
       v.destroy_unused_network_interfaces = true
@@ -26,6 +28,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     testvm.ssh.port = 2402
     testvm.vm.network "forwarded_port", guest: 22, host: testvm.ssh.port, host_ip: "127.0.0.1"
     testvm.vm.network "private_network", ip: "192.168.33.71"
+    ## EOL for CentOS 6 so using the package location in http://vault.centos.org
+    testvm.vm.provision "shell", inline: "sed -ibck  's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-Base.repo"
     testvm.vm.provision "shell", inline: "yum install -y libselinux-python"
     testvm.vm.provider "virtualbox" do |v|
       v.destroy_unused_network_interfaces = true


### PR DESCRIPTION
### What

> CentOS Linux 6 EOL
As has been announced everywhere for the past year (and more!) CentOS 6 has been moved to End Of Life (EOL) status as of November 30th, 2020. During the first week in December 2020, the 6.10 directory will move to vault.centos.org

> Packages will still be available at: http://vault.centos.org/centos/6.10/. However, once moved, there will be no more updates pushed to vault.centos.org. Therefore, security issues will no longer be fixed.

### Issue 

Closes https://github.com/elastic/beats-tester/issues/187