### PR TITLE
Fix checksum validation

### DIFF
--- a/roles/common/tasks/download.yml
+++ b/roles/common/tasks/download.yml
@@ -5,7 +5,7 @@
     dest: "{{workdir}}"
     validate_certs: no
     timeout: 60
-    checksum: "sha512:{{beat_url}}.sha512"
+    checksum: "sha512:{{ lookup('url', beat_url + '.sha512') }}"
   when: ansible_os_family != "Windows"
 
 - name: Download package with checksum (windows)


### PR DESCRIPTION
Attempt to fix issue where `get_url` doesn't properly read a checksum value out of a checksum file:

https://github.com/ansible/ansible/issues/54390

Needs testing but should address https://github.com/elastic/observability-robots/issues/579