### PR TITLE
Attempting to scope the checksum within the download role

### DIFF
--- a/roles/common/tasks/download.yml
+++ b/roles/common/tasks/download.yml
@@ -1,8 +1,6 @@
-- name: Extract beat checksum (linux/darwin)
-  set_fact: beat_sha512="{{ lookup('url', beat_url + '.sha512', split_lines=False) | trim }}"
-  when: ansible_os_family != "Windows"
-
 - name: Download package with checksum (linux/darwin)
+  vars:
+    - beat_sha512: "{{ lookup('url', beat_url + '.sha512', split_lines=False) | trim }}"
   get_url:
     url: "{{beat_url}}"
     dest: "{{workdir}}"


### PR DESCRIPTION
I think set_fact could be colliding with multiple lookups for different beats
and a mismatch is occuring when the validation happens

For example, when doing parallel deploys, set_fact may be a global state thing and could contain the incorrect beat_sha512 variable for the package being downloaded

ref:https://github.com/elastic/observability-robots/issues/579

Signed-off-by: Adam Stokes <51892+adam-stokes@users.noreply.github.com>