### PR TITLE
Force no-cache on artifact requests

### DIFF
--- a/packages.yml
+++ b/packages.yml
@@ -411,10 +411,10 @@
     - project: beats
   roles:
     - role: common
-      when: version is version_compare('6.2', '>=') inventory_hostname.endswith('64')
+      when: version is version_compare('6.2', '>=') and inventory_hostname.endswith('64')
     - role: test-install
-      when: version is version_compare('6.2', '>=') inventory_hostname.endswith('64')
+      when: version is version_compare('6.2', '>=') and inventory_hostname.endswith('64')
     - role: test-beat
-      when: version is version_compare('6.2', '>=') inventory_hostname.endswith('64')
+      when: version is version_compare('6.2', '>=') and inventory_hostname.endswith('64')
     - role: test-uninstall
-      when: version is version_compare('6.2', '>=') inventory_hostname.endswith('64')
+      when: version is version_compare('6.2', '>=') and inventory_hostname.endswith('64')

--- a/packages.yml
+++ b/packages.yml
@@ -351,7 +351,7 @@
       when: inventory_hostname.endswith('x86')
     - role: test-install
       when: inventory_hostname.endswith('x86')
-    - role:test-beat
+    - role: test-beat
       when: inventory_hostname.endswith('x86')
     - role: test-uninstall
       when: inventory_hostname.endswith('x86')

--- a/packages.yml
+++ b/packages.yml
@@ -159,13 +159,13 @@
     - win_arch: x86
     - project: beats
   roles:
-    - common
+    - role: common
       when: inventory_hostname.endswith('x86')
-    - test-install
+    - role: test-install
       when: inventory_hostname.endswith('x86')
-    - test-beat
+    - role: test-beat
       when: inventory_hostname.endswith('x86')
-    - test-uninstall
+    - role: test-uninstall
       when: inventory_hostname.endswith('x86')
 
 - name: Packaging windows x86_64 tests for APM Server
@@ -200,13 +200,13 @@
     - win_arch: x86_64
     - project: beats
   roles:
-    - common
+    - role: common
       when: inventory_hostname.endswith('x86')
-    - test-install
+    - role: test-install
       when: inventory_hostname.endswith('x86')
-    - test-beat
+    - role: test-beat
       when: inventory_hostname.endswith('x86')
-    - test-uninstall
+    - role: test-uninstall
       when: inventory_hostname.endswith('x86')
 
 - name: Packaging windows x86 tests for Metricbeat
@@ -221,13 +221,13 @@
     - win_arch: x86
     - project: beats
   roles:
-    - common
+    - role: common
       when: inventory_hostname.endswith('x86')
-    - test-install
+    - role: test-install
       when: inventory_hostname.endswith('x86')
-    - test-beat
+    - role: test-beat
       when: inventory_hostname.endswith('x86')
-    - test-uninstall
+    - role: test-uninstall
       when: inventory_hostname.endswith('x86')
 
 - name: Packaging windows x86_64 tests for Metricbeat
@@ -242,13 +242,13 @@
     - win_arch: x86_64
     - project: beats
   roles:
-    - common
+    - role: common
       when: inventory_hostname.endswith('64')
-    - test-install
+    - role: test-install
       when: inventory_hostname.endswith('64')
-    - test-beat
+    - role: test-beat
       when: inventory_hostname.endswith('64')
-    - test-uninstall
+    - role: test-uninstall
       when: inventory_hostname.endswith('64')
 
 - name: Packaging windows x86 tests for Filebeat
@@ -263,13 +263,13 @@
     - win_arch: x86
     - project: beats
   roles:
-    - common
+    - role: common
       when: inventory_hostname.endswith('x86')
-    - test-install
+    - role: test-install
       when: inventory_hostname.endswith('x86')
-    - test-beat
+    - role: test-beat
       when: inventory_hostname.endswith('x86')
-    - test-uninstall
+    - role: test-uninstall
       when: inventory_hostname.endswith('x86')
 
 - name: Packaging windows x86_64 tests for Filebeat
@@ -284,13 +284,13 @@
     - win_arch: x86_64
     - project: beats
   roles:
-    - common
+    - role: common
       when: inventory_hostname.endswith('64')
-    - test-install
+    - role: test-install
       when: inventory_hostname.endswith('64')
-    - test-beat
+    - role: test-beat
       when: inventory_hostname.endswith('64')
-    - test-uninstall
+    - role: test-uninstall
       when: inventory_hostname.endswith('64')
 
 - name: Packaging windows x86 tests for Heartbeat
@@ -305,13 +305,13 @@
     - win_arch: x86
     - project: beats
   roles:
-    - common
+    - role: common
       when: inventory_hostname.endswith('x86')
-    - test-install
+    - role: test-install
       when: inventory_hostname.endswith('x86')
-    - test-beat
+    - role: test-beat
       when: inventory_hostname.endswith('x86')
-    - test-uninstall
+    - role: test-uninstall
       when: inventory_hostname.endswith('x86')
 
 - name: Packaging windows x86_64 tests for Heartbeat
@@ -326,13 +326,13 @@
     - win_arch: x86_64
     - project: beats
   roles:
-    - common
+    - role: common
       when: inventory_hostname.endswith('64')
-    - test-install
+    - role: test-install
       when: inventory_hostname.endswith('64')
-    - test-beat
+    - role: test-beat
       when: inventory_hostname.endswith('64')
-    - test-uninstall
+    - role: test-uninstall
       when: inventory_hostname.endswith('64')
 
 - name: Packaging windows x86 tests for Winlogbeat
@@ -347,13 +347,13 @@
     - win_arch: x86
     - project: beats
   roles:
-    - common
+    - role: common
       when: inventory_hostname.endswith('x86')
-    - test-install
+    - role: test-install
       when: inventory_hostname.endswith('x86')
-    - test-beat
+    - role:test-beat
       when: inventory_hostname.endswith('x86')
-    - test-uninstall
+    - role: test-uninstall
       when: inventory_hostname.endswith('x86')
 
 - name: Packaging windows x86_64 tests for Winlogbeat
@@ -368,13 +368,13 @@
     - win_arch: x86_64
     - project: beats
   roles:
-    - common
+    - role: common
       when: inventory_hostname.endswith('64')
-    - test-install
+    - role: test-install
       when: inventory_hostname.endswith('64')
-    - test-beat
+    - role: test-beat
       when: inventory_hostname.endswith('64')
-    - test-uninstall
+    - role: test-uninstall
       when: inventory_hostname.endswith('64')
 
 - name: Packaging windows x86 tests for Auditbeat

--- a/packages.yml
+++ b/packages.yml
@@ -160,9 +160,13 @@
     - project: beats
   roles:
     - common
+      when: inventory_hostname.endswith('x86')
     - test-install
+      when: inventory_hostname.endswith('x86')
     - test-beat
+      when: inventory_hostname.endswith('x86')
     - test-uninstall
+      when: inventory_hostname.endswith('x86')
 
 - name: Packaging windows x86_64 tests for APM Server
   hosts:
@@ -197,9 +201,13 @@
     - project: beats
   roles:
     - common
+      when: inventory_hostname.endswith('x86')
     - test-install
+      when: inventory_hostname.endswith('x86')
     - test-beat
+      when: inventory_hostname.endswith('x86')
     - test-uninstall
+      when: inventory_hostname.endswith('x86')
 
 - name: Packaging windows x86 tests for Metricbeat
   hosts:
@@ -214,9 +222,13 @@
     - project: beats
   roles:
     - common
+      when: inventory_hostname.endswith('x86')
     - test-install
+      when: inventory_hostname.endswith('x86')
     - test-beat
+      when: inventory_hostname.endswith('x86')
     - test-uninstall
+      when: inventory_hostname.endswith('x86')
 
 - name: Packaging windows x86_64 tests for Metricbeat
   hosts:
@@ -231,9 +243,13 @@
     - project: beats
   roles:
     - common
+      when: inventory_hostname.endswith('64')
     - test-install
+      when: inventory_hostname.endswith('64')
     - test-beat
+      when: inventory_hostname.endswith('64')
     - test-uninstall
+      when: inventory_hostname.endswith('64')
 
 - name: Packaging windows x86 tests for Filebeat
   hosts:
@@ -248,9 +264,13 @@
     - project: beats
   roles:
     - common
+      when: inventory_hostname.endswith('x86')
     - test-install
+      when: inventory_hostname.endswith('x86')
     - test-beat
+      when: inventory_hostname.endswith('x86')
     - test-uninstall
+      when: inventory_hostname.endswith('x86')
 
 - name: Packaging windows x86_64 tests for Filebeat
   hosts:
@@ -265,9 +285,13 @@
     - project: beats
   roles:
     - common
+      when: inventory_hostname.endswith('64')
     - test-install
+      when: inventory_hostname.endswith('64')
     - test-beat
+      when: inventory_hostname.endswith('64')
     - test-uninstall
+      when: inventory_hostname.endswith('64')
 
 - name: Packaging windows x86 tests for Heartbeat
   hosts:
@@ -282,9 +306,13 @@
     - project: beats
   roles:
     - common
+      when: inventory_hostname.endswith('x86')
     - test-install
+      when: inventory_hostname.endswith('x86')
     - test-beat
+      when: inventory_hostname.endswith('x86')
     - test-uninstall
+      when: inventory_hostname.endswith('x86')
 
 - name: Packaging windows x86_64 tests for Heartbeat
   hosts:
@@ -299,9 +327,13 @@
     - project: beats
   roles:
     - common
+      when: inventory_hostname.endswith('64')
     - test-install
+      when: inventory_hostname.endswith('64')
     - test-beat
+      when: inventory_hostname.endswith('64')
     - test-uninstall
+      when: inventory_hostname.endswith('64')
 
 - name: Packaging windows x86 tests for Winlogbeat
   hosts:
@@ -316,9 +348,13 @@
     - project: beats
   roles:
     - common
+      when: inventory_hostname.endswith('x86')
     - test-install
+      when: inventory_hostname.endswith('x86')
     - test-beat
+      when: inventory_hostname.endswith('x86')
     - test-uninstall
+      when: inventory_hostname.endswith('x86')
 
 - name: Packaging windows x86_64 tests for Winlogbeat
   hosts:
@@ -333,9 +369,13 @@
     - project: beats
   roles:
     - common
+      when: inventory_hostname.endswith('64')
     - test-install
+      when: inventory_hostname.endswith('64')
     - test-beat
+      when: inventory_hostname.endswith('64')
     - test-uninstall
+      when: inventory_hostname.endswith('64')
 
 - name: Packaging windows x86 tests for Auditbeat
   hosts:
@@ -350,13 +390,13 @@
     - project: beats
   roles:
     - role: common
-      when: "version is version_compare('6.2', '>=')"
+      when: version is version_compare('6.2', '>=') and inventory_hostname.endswith('x86')
     - role: test-install
-      when: "version is version_compare('6.2', '>=')"
+      when: version is version_compare('6.2', '>=') and inventory_hostname.endswith('x86')
     - role: test-beat
-      when: "version is version_compare('6.2', '>=')"
+      when: version is version_compare('6.2', '>=') and inventory_hostname.endswith('x86')
     - role: test-uninstall
-      when: "version is version_compare('6.2', '>=')"
+      when: version is version_compare('6.2', '>=') and inventory_hostname.endswith('x86')
 
 - name: Packaging windows x86_64 tests for Auditbeat
   hosts:
@@ -371,10 +411,10 @@
     - project: beats
   roles:
     - role: common
-      when: "version is version_compare('6.2', '>=')"
+      when: version is version_compare('6.2', '>=') inventory_hostname.endswith('64')
     - role: test-install
-      when: "version is version_compare('6.2', '>=')"
+      when: version is version_compare('6.2', '>=') inventory_hostname.endswith('64')
     - role: test-beat
-      when: "version is version_compare('6.2', '>=')"
+      when: version is version_compare('6.2', '>=') inventory_hostname.endswith('64')
     - role: test-uninstall
-      when: "version is version_compare('6.2', '>=')"
+      when: version is version_compare('6.2', '>=') inventory_hostname.endswith('64')

--- a/roles/common/tasks/download.yml
+++ b/roles/common/tasks/download.yml
@@ -10,11 +10,13 @@
   when: ansible_os_family != "Windows"
 
 - name: Download package with checksum (windows)
+  vars:
+    - win_beat_sha512: "{{ lookup('url', beat_url + '.sha512?ignoreCache=1', split_lines=False) | trim }}"
   win_get_url:
     url: "{{beat_url}}'"
     dest: "{{workdir}}"
     validate_certs: no
     timeout: 60
-    checksum_url: "{{beat_url}}.sha512?ignoreCache=1"
+    checksum: "sha512:{{ win_beat_sha512.split()[0] }}"
     checksum_algorithm: sha512
   when: ansible_os_family == "Windows"

--- a/roles/common/tasks/download.yml
+++ b/roles/common/tasks/download.yml
@@ -2,7 +2,7 @@
   vars:
     - beat_sha512: "{{ lookup('url', beat_url + '.sha512?ignoreCache=1', split_lines=False) | trim }}"
   get_url:
-    url: "{{beat_url}} + '?ignoreCache=1"
+    url: "{{beat_url}}"
     dest: "{{workdir}}"
     validate_certs: no
     timeout: 60
@@ -11,7 +11,7 @@
 
 - name: Download package with checksum (windows)
   win_get_url:
-    url: "{{beat_url}} + '?ignoreCache=1'"
+    url: "{{beat_url}}'"
     dest: "{{workdir}}"
     validate_certs: no
     timeout: 60

--- a/roles/common/tasks/download.yml
+++ b/roles/common/tasks/download.yml
@@ -1,6 +1,6 @@
 - name: Download package with checksum (linux/darwin)
   vars:
-    - beat_sha512: "{{ lookup('url', beat_url + '.sha512', split_lines=False) | trim }}"
+    - beat_sha512: "{{ lookup('url', beat_url + '.sha512?ignoreCache=1', split_lines=False) | trim }}"
   get_url:
     url: "{{beat_url}}"
     dest: "{{workdir}}"
@@ -15,6 +15,6 @@
     dest: "{{workdir}}"
     validate_certs: no
     timeout: 60
-    checksum_url: "{{beat_url}}.sha512"
+    checksum_url: "{{beat_url}}.sha512?ignoreCache=1"
     checksum_algorithm: sha512
   when: ansible_os_family == "Windows"

--- a/roles/common/tasks/download.yml
+++ b/roles/common/tasks/download.yml
@@ -13,7 +13,7 @@
   vars:
     - win_beat_sha512: "{{ lookup('url', beat_url + '.sha512?ignoreCache=1', split_lines=False) | trim }}"
   win_get_url:
-    url: "{{beat_url}}'"
+    url: "{{beat_url}}"
     dest: "{{workdir}}"
     validate_certs: no
     timeout: 60

--- a/roles/common/tasks/download.yml
+++ b/roles/common/tasks/download.yml
@@ -17,6 +17,6 @@
     dest: "{{workdir}}"
     validate_certs: no
     timeout: 60
-    checksum: "sha512:{{ win_beat_sha512.split()[0] }}"
+    checksum: "{{ win_beat_sha512.split()[0] }}"
     checksum_algorithm: sha512
   when: ansible_os_family == "Windows"

--- a/roles/common/tasks/download.yml
+++ b/roles/common/tasks/download.yml
@@ -2,7 +2,7 @@
   vars:
     - beat_sha512: "{{ lookup('url', beat_url + '.sha512?ignoreCache=1', split_lines=False) | trim }}"
   get_url:
-    url: "{{beat_url}}"
+    url: "{{beat_url}} + '?ignoreCache=1"
     dest: "{{workdir}}"
     validate_certs: no
     timeout: 60
@@ -11,7 +11,7 @@
 
 - name: Download package with checksum (windows)
   win_get_url:
-    url: "{{beat_url}}"
+    url: "{{beat_url}} + '?ignoreCache=1'"
     dest: "{{workdir}}"
     validate_certs: no
     timeout: 60


### PR DESCRIPTION
This should fully resolve https://github.com/elastic/observability-robots/issues/579 and is the correct fix for https://github.com/elastic/beats-tester/pull/202

The problem here turned out to be that GCE aggressively sets cache-control headers on objects resulting in Ansible downloading incorrect checksum data. 

In ad-hoc testing, I varying times for this cache expiration for a bucket that was configured in a similar way to the current artifact bucket but some of them were as low as ~5 minutes, which would explain why this problem presents itself as a race condition. This pipeline is typically run downstream of the main APM Server pipeline which means that we're racing the cache expiration.

This fix works around the issue by simply passing in the `ignoreCache=1` flag to all requests to GCE.

A better solution would be [to set Cache-Control metadata on the object during its creation](https://cloud.google.com/storage/docs/gsutil/addlhelp/WorkingWithObjectMetadata), but in testing this I could not get GCE to respect this setting. As a result, I chose to fix it client-side for the time being.

In the event caching can be reliably disabled on artifacts in the GCE bucket, the workaround in this PR could be reverted.

cc: @adam-stokes @v1v 