### PR TITLE
Use force=True for cache-control

### DIFF
--- a/roles/common/tasks/download.yml
+++ b/roles/common/tasks/download.yml
@@ -1,6 +1,6 @@
 - name: Download package with checksum (linux/darwin)
   vars:
-    - beat_sha512: "{{ lookup('url', beat_url + '.sha512?ignoreCache=1', split_lines=False) | trim }}"
+    - beat_sha512: "{{ lookup('url', beat_url + '.sha512', split_lines=False, force=True) | trim }}"
   get_url:
     url: "{{beat_url}}"
     dest: "{{workdir}}"
@@ -11,7 +11,7 @@
 
 - name: Download package with checksum (windows)
   vars:
-    - win_beat_sha512: "{{ lookup('url', beat_url + '.sha512?ignoreCache=1', split_lines=False) | trim }}"
+    - win_beat_sha512: "{{ lookup('url', beat_url + '.sha512', split_lines=False, force=True) | trim }}"
   win_get_url:
     url: "{{beat_url}}"
     dest: "{{workdir}}"


### PR DESCRIPTION
The previous attempt to fix this issue [was not successful](https://apm-ci.elastic.co/blue/organizations/jenkins/apm-server%2Fapm-server-check-packages-mbp/detail/master/742/pipeline/92). 

We're going to try again but this time set the cache-control header [using the Ansible option](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/url_lookup.html).