### PR TITLE
apm-server should not wait for integration

### DIFF
--- a/roles/test-beat/templates/apm-server.yml.j2
+++ b/roles/test-beat/templates/apm-server.yml.j2
@@ -1,4 +1,8 @@
 apm-server:
+  data_streams:
+    # We aren't writing to Elasticsearch, so there is no
+    # need to wait for the integration to be installed.
+    wait_for_integration: false
 logging:
   level: info
   json: true


### PR DESCRIPTION
beats-tester configures apm-server to write events to a file, rather than to Elasticsearch. In this mode it is necessary to explicitly tell apm-server not to wait for the integration package to be installed.