### PR TITLE
Update docs with the requirements to run the ansible playbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,13 @@ ubuntu1804-64 | :white_check_mark:
 ubuntu2004-64 | :white_check_mark:
 win12-64 | :white_check_mark:
 
+## Requirements
+
+* Python version <= `3.8`
+* Ansible version <= `2.8.8`
+
+Those versions are defined in the `requirements.txt`.
+
 ## Execute
 
 First, you need to bring the machines up:


### PR DESCRIPTION
### What

If running the ansible playbook with python 3.9 then

```
"/usr/local/Cellar/python@3.9/3.9.9/Frameworks/Python.framework/Versions/3.9/lib/python3.9/multiprocessing/reduction.py", line 60, in dump
    ForkingPickler(file, protocol).dump(obj)
TypeError: cannot pickle '_io.TextIOWrapper' object
make: *** [ansible-playbook-run-elastic] Error 250
```



### Issue

See https://github.com/ansible/ansible/issues/63973#issuecomment-546967422