### PR TITLE
ci: trying to fix some issues with reached limited number of git commit status

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -41,7 +41,7 @@ pipeline {
       steps {
         pipelineManager([ cancelPreviousRunningBuilds: [ when: 'PR' ] ])
         deleteDir()
-        gitCheckout(basedir: "${BASE_DIR}", githubNotifyFirstTimeContributor: true)
+        gitCheckout(basedir: "${BASE_DIR}", githubNotifyFirstTimeContributor: false)
         stash allowEmpty: true, name: 'source', useDefaultExcludes: false
       }
     }


### PR DESCRIPTION
Error

```
21:42:58  hudson.remoting.ProxyException: org.kohsuke.github.HttpException: {"message":"Validation Failed","errors":[{"resource":"Status","code":"custom","message":"This SHA and context has reached the maximum number of statuses."}],"documentation_url":"https://docs.github.com/rest/commits/statuses#create-a-commit-status"}
21:42:58  	at org.kohsuke.github.GitHubConnectorResponseErrorHandler$1.onError(GitHubConnectorResponseErrorHandler.java:56)
21:42:58  	at org.kohsuke.github.GitHubClient.detectKnownErrors(GitHubClient.java:424)
21:42:58  	at org.kohsuke.github.GitHubClient.sendRequest(GitHubClient.java:386)
21:42:58  	at org.kohsuke.github.GitHubClient.sendRequest(GitHubClient.java:355)
21:42:58  	at org.kohsuke.github.Requester.fetch(Requester.java:76)
21:42:58  	at org.kohsuke.github.GHRepository.createCommitStatus(GHRepository.java:2107)
21:
```

My guess, the same commit has been used for running a few dozens of builds and maybe it contains a bunch of commit status... Otherwise I've no clue what's the reason