### PR TITLE
ci: use standard github commands (/test)

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -28,7 +28,7 @@ pipeline {
     rateLimitBuilds(throttle: [count: 8, durationName: 'hour', userBoost: true])
   }
   triggers {
-    issueCommentTrigger('(?i).*(?:jenkins\\W+)?run\\W+(?:the\\W+)?tests(?:\\W+please)?.*')
+    issueCommentTrigger("${obltGitHubComments()}")
   }
   parameters {
     string(name: 'APM_URL_BASE', defaultValue: 'https://snapshots.elastic.co/downloads/apm-server', description: 'The location where the APM packages should be downloaded from')


### PR DESCRIPTION
`    issueCommentTrigger('(?i).*(?:jenkins\\W+)?run\\W+(?:the\\W+)?tests(?:\\W+please)?.*')` was about 3 years old but we moved to use something else across all the projects so we didn't need to hardcode the same string in each Jenkinsfile.