### PR TITLE
Disable concurrent builds

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -32,7 +32,7 @@ pipeline {
   }
   parameters {
     string(name: 'BEATS_URL_BASE', defaultValue: 'https://storage.googleapis.com/beats-ci-artifacts/beats/snapshots', description: 'The location where the Beats packages should be downloaded from')
-    string(name: 'VERSION', defaultValue: '8.8.0-SNAPSHOT', description: 'The package version to test (modify the job configuration to add a new version)')
+    string(name: 'VERSION', defaultValue: '8.10.0-SNAPSHOT', description: 'The package version to test (modify the job configuration to add a new version)')
   }
   stages {
     stage('Checkout') {

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -25,6 +25,7 @@ pipeline {
     durabilityHint('PERFORMANCE_OPTIMIZED')
     quietPeriod(10)
     rateLimitBuilds(throttle: [count: 8, durationName: 'hour', userBoost: true])
+    disableConcurrentBuilds()
   }
   triggers {
     issueCommentTrigger("${obltGitHubComments()}")

--- a/README.md
+++ b/README.md
@@ -27,8 +27,16 @@ win12-64 | :white_check_mark:
 Those versions are defined in the `requirements.txt`.
 
 ## Execute
+First, for Linux and macOS, you need to enable some IP address range
+for the host-only network. To do so, create (or edit)
+`/etc/vbox/networks.conf` and add the following range there:
+```
+192.168.33.0/24
+```
+For more information, check [the official
+documentation](https://www.virtualbox.org/manual/ch06.html#network_hostonly)
 
-First, you need to bring the machines up:
+Second, you need to bring the machines up:
 
     make setup
 


### PR DESCRIPTION
Concurrent builds seem to be running on the same workspace/folder which is generating some race conditions and making the pipeline flaky. This commit disables concurrent builds. It also improves the documentation.